### PR TITLE
Dependency update...

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/cydran/cydran",
   "devDependencies": {
     "@types/chai": "4.1.7",
-    "@types/lodash": "4.14.123",
+    "@types/lodash": "4.14.129",
     "babel-core": "6.26.3",
     "babel-loader": "^7.1.5",
     "babel-preset-env": "1.7.0",
@@ -45,7 +45,7 @@
     "typescript": "3.4.5",
     "uglify-js": "^3.5.11",
     "webpack": "4.30.0",
-    "webpack-cli": "3.3.1",
+    "webpack-cli": "3.3.2",
     "webpack-node-externals": "1.7.2",
     "webpack-shell-plugin": "0.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "tslint": "5.16.0",
     "typescript": "3.4.5",
     "uglify-js": "^3.5.11",
-    "webpack": "4.30.0",
+    "webpack": "4.31.0",
     "webpack-cli": "3.3.2",
     "webpack-node-externals": "1.7.2",
     "webpack-shell-plugin": "0.5.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "mocha": "6.1.4",
     "raw-loader": "2.0.0",
     "rimraf": "2.6.3",
-    "ts-loader": "5.4.4",
+    "ts-loader": "6.0.0",
     "tslint": "5.16.0",
     "typescript": "3.4.5",
     "uglify-js": "^3.5.11",


### PR DESCRIPTION
Verified all updated here to lib version dependencies.  babel-loader is still missing major upgrade (to 8.x) but it breaks the build.  This build verified.