### PR TITLE
Removed direct registration of the stage with the window object.

### DIFF
--- a/src/Stage.ts
+++ b/src/Stage.ts
@@ -15,7 +15,6 @@ class Stage extends Component {
 		this.started = false;
 		this.rootId = rootId;
 		this.initializers = [];
-		window["stage"] = this;
 	}
 
 	public withInitializer(callback: () => void): Stage {


### PR DESCRIPTION
After this change, doing something like the following explicitly in your
code is required:

window['stage'] = stage;