### PR TITLE
Removal of duplicate code in repeat

### DIFF
--- a/src/element/repeat/Repeat.ts
+++ b/src/element/repeat/Repeat.ts
@@ -257,34 +257,22 @@ class Repeat extends ElementMediator<any[], HTMLElement, Params> {
 					el.appendChild(this.empty.getEl());
 				}
 			} else {
-				if (this.elIsSelect) {
-					if (this.first) {
-						el.appendChild(this.first.getEl());
-					}
+				const workingEl: HTMLElement | DocumentFragment
+					= (this.elIsSelect) ? el : Properties.getWindow().document.createDocumentFragment();
 
-					for (const component of components) {
-						el.appendChild(component.getEl());
-					}
+				if (this.first) {
+					workingEl.appendChild(this.first.getEl());
+				}
 
-					if (this.last) {
-						el.appendChild(this.last.getEl());
-					}
-				} else {
-					const fragment: DocumentFragment = Properties.getWindow().document.createDocumentFragment();
+				for (const component of components) {
+					workingEl.appendChild(component.getEl());
+				}
 
-					if (this.first) {
-						fragment.appendChild(this.first.getEl());
-					}
-
-					for (const component of components) {
-						fragment.appendChild(component.getEl());
-					}
-
-					if (this.last) {
-						fragment.appendChild(this.last.getEl());
-					}
-
-					el.appendChild(fragment);
+				if (this.last) {
+					workingEl.appendChild(this.last.getEl());
+				}
+				if (!this.elIsSelect) {
+					el.appendChild(workingEl);
 				}
 			}
 		}

--- a/src/element/repeat/Repeat.ts
+++ b/src/element/repeat/Repeat.ts
@@ -249,7 +249,7 @@ class Repeat extends ElementMediator<any[], HTMLElement, Params> {
 			const el: HTMLElement = this.getEl();
 
 			while (el.firstChild) {
-				el.removeChild(el.firstChild);
+				el.removeChild(el.lastChild);
 			}
 
 			if (components.length === 0) {


### PR DESCRIPTION
Looking through the repeat code for potential performance improvements yielded a smaller surface area to have to debug against.  Also made a change to removing old Element nodes by last child on the array vs first to avoid computationally expensive re-index with every first child removed.