### PR TITLE
Issue 539 - Support name option

### DIFF
--- a/src/component/Component.ts
+++ b/src/component/Component.ts
@@ -102,6 +102,10 @@ class Component implements Nestable {
 		return this.____internal$$cydran____.getPrefix();
 	}
 
+	public getName(): string {
+		return this.____internal$$cydran____.getName();
+	}
+
 	public isMounted(): boolean {
 		return this.____internal$$cydran____.isMounted();
 	}

--- a/src/component/ComponentInternals.ts
+++ b/src/component/ComponentInternals.ts
@@ -43,6 +43,8 @@ interface ComponentInternals extends Digestable, Tellable, DigestableSource {
 
 	getEl(): HTMLElement;
 
+	getName(): string;
+
 	getExtractor(): Attributes;
 
 	getId(): string;

--- a/src/component/ComponentInternalsImpl.ts
+++ b/src/component/ComponentInternalsImpl.ts
@@ -549,7 +549,7 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 
 	private initFields(): void {
 		this.id = IdGenerator.INSTANCE.generate();
-		this.logger = LoggerFactory.getLogger(`${this.options.name} component ${this.id}`);
+		this.logger = LoggerFactory.getLogger(`${this.getName()} component ${this.id}`);
 		this.regions = new AdvancedMapImpl<Region>();
 		this.anonymousRegionNameIndex = 0;
 		this.propagatingBehaviors = [];

--- a/src/component/ComponentInternalsImpl.ts
+++ b/src/component/ComponentInternalsImpl.ts
@@ -155,6 +155,10 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 		this.options = merge([DEFAULT_COMPONENT_OPTIONS, this.options], { metadata: (existingValue: any, newValue: any) => merge([existingValue, newValue])});
 		this.options.prefix = this.options.prefix.toLowerCase();
 
+		if (!isDefined(this.options.name) || this.options.name.trim().length === 0) {
+			this.options.name = this.component.constructor.name;
+		}
+
 		if (isDefined(this.options.module)) {
 			this.component[MODULE_FIELD_NAME] = this.options.module;
 		}
@@ -381,6 +385,10 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 		this.pubSub.on(messageName).forChannel(channel || INTERNAL_CHANNEL_NAME).invoke((payload: any) => this.$apply(target, [payload]));
 	}
 
+	public getName(): string {
+		return this.options.name;
+	}
+
 	public forElement<E extends HTMLElement>(name: string): ElementOperations<E> {
 		requireNotNull(name, "name");
 		const element: E = this.getNamedElement(name) as E;
@@ -541,7 +549,7 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 
 	private initFields(): void {
 		this.id = IdGenerator.INSTANCE.generate();
-		this.logger = LoggerFactory.getLogger(`${this.component.constructor.name} component ${this.id}`);
+		this.logger = LoggerFactory.getLogger(`${this.options.name} component ${this.id}`);
 		this.regions = new AdvancedMapImpl<Region>();
 		this.anonymousRegionNameIndex = 0;
 		this.propagatingBehaviors = [];

--- a/src/component/InternalComponentOptions.ts
+++ b/src/component/InternalComponentOptions.ts
@@ -14,6 +14,8 @@ interface InternalComponentOptions extends ComponentOptions {
 
 	parent?: Nestable;
 
+	name?: string;
+
 }
 
 export default InternalComponentOptions;


### PR DESCRIPTION
Adds support for a name option for components that is used in creating the logger name as well as being available via the getName() method.