### PR TITLE
Add withProperties for builder back into the mix - resolves #554

### DIFF
--- a/src/stage/Stage.ts
+++ b/src/stage/Stage.ts
@@ -63,6 +63,8 @@ interface StageBuilder extends Builder<Stage> {
 
 	withConstant(id: string, instance: any): StageBuilder;
 
+	withProperties(properties: any): StageBuilder;
+
 	withPrototype(id: string, classInstance: Type<any>, argumentResolvers?: ArgumentsResolvers): StageBuilder;
 
 	withPrototypeFromFactory(id: string, factoryFn: () => any, argumentResolvers?: ArgumentsResolvers): StageBuilder;

--- a/src/stage/StageBulderImpl.ts
+++ b/src/stage/StageBulderImpl.ts
@@ -75,6 +75,11 @@ class StageBuilderImpl extends AbstractBuilderImpl<Stage, StageImpl> implements 
 		return this;
 	}
 
+	public withProperties(properties: any): StageBuilder {
+		this.getInstance().getProperties().load(properties);
+		return this;
+	}
+
 	public withPrototype(id: string, classInstance: Type<any>, argumentResolvers?: ArgumentsResolvers): StageBuilder {
 		this.getInstance().getModules().registerPrototype(id, classInstance, argumentResolvers);
 		return this;


### PR DESCRIPTION
Needed to be able to load properties at a cydran "capability"/module level