### PR TITLE
#561 id generator exposure

### DIFF
--- a/src/argument/ArgumentResolversBuilderImpl.ts
+++ b/src/argument/ArgumentResolversBuilderImpl.ts
@@ -8,6 +8,7 @@ import ObjectArgumentResolver from "argument/ObjectArgumentResolver";
 import PubSubArgumentResolver from 'argument/PubSubArgumentResolver';
 import AbstractBuilderImpl from 'pattern/AbstractBuilderImpl';
 import ScopeItemArgumentResolver from "argument/ScopeItemArgumentResolver";
+import InstanceIdArgumentResolver from "argument/InstanceIdArgumentResolver";
 
 class ArgumentResolversBuilderImpl extends AbstractBuilderImpl<ArgumentsResolvers, ArgumentsResolversImpl> implements ArgumentsResolversBuilder {
 
@@ -17,6 +18,11 @@ class ArgumentResolversBuilderImpl extends AbstractBuilderImpl<ArgumentsResolver
 
 	public with(id: string): ArgumentsResolversBuilder {
 		this.getInstance().add(new ObjectArgumentResolver(id));
+		return this;
+	}
+
+	withInstanceId(): ArgumentsResolversBuilder {
+		this.getInstance().add(new InstanceIdArgumentResolver());
 		return this;
 	}
 

--- a/src/argument/FunctionArgumentResolver.ts
+++ b/src/argument/FunctionArgumentResolver.ts
@@ -2,6 +2,7 @@ import Module from "module/Module";
 import ArgumentResolver from 'argument/ArgumentResolver';
 import { requireNotNull, isDefined } from 'util/Utils';
 import { IllegalArgumentError } from "error/Errors";
+import JSType from "const/JSType";
 
 type WkFunction = ReturnType<() => any>;
 class FunctionArgumentResolver implements ArgumentResolver {
@@ -9,13 +10,13 @@ class FunctionArgumentResolver implements ArgumentResolver {
 
 	constructor(fn: WkFunction) {
 		this.fn = requireNotNull(fn, "fn");
-		if(typeof fn !== 'function') {
+		if(typeof fn !== JSType.FN) {
 			throw new IllegalArgumentError("supplied argument not a funciton");
 		}
 	}
 
 	public resolve(module: Module): any {
-		const instance: any = (typeof this.fn === 'function') ? this.fn() : null;
+		const instance: any = (typeof this.fn === JSType.FN) ? this.fn() : null;
 
 		return instance;
 	}

--- a/src/argument/InstanceIdArgumentResolver.ts
+++ b/src/argument/InstanceIdArgumentResolver.ts
@@ -1,0 +1,17 @@
+import Module from "module/Module";
+import ArgumentResolver from 'argument/ArgumentResolver';
+import IdGenerator from "util/IdGenerator";
+
+class InstanceIdArgumentResolver implements ArgumentResolver {
+
+	public resolve(module: Module): any {
+		return IdGenerator.INSTANCE.generate();
+	}
+
+	public postProcess(module: Module, target: any, param: any): void {
+		// Intentionally do nothing
+	}
+
+}
+
+export default InstanceIdArgumentResolver;

--- a/src/stage/Stage.ts
+++ b/src/stage/Stage.ts
@@ -86,6 +86,8 @@ interface ArgumentsResolversBuilder extends Builder<ArgumentsResolvers> {
 
 	withPubSub(): ArgumentsResolversBuilder;
 
+	withInstanceId(): ArgumentsResolversBuilder;
+
 	withFunction(fn: () => any): ArgumentsResolversBuilder;
 
 	withConstant(value: any): ArgumentsResolversBuilder;

--- a/test/argument/ArgumentResolversBuilderImpl.spec.ts
+++ b/test/argument/ArgumentResolversBuilderImpl.spec.ts
@@ -28,6 +28,12 @@ test("withPubSub", () => {
 	expect(wkSpy).toBeCalledTimes(1);
 });
 
+test("withInstanceId", () => {
+	const wkSpy = jest.spyOn(builder, 'withInstanceId');
+	builder.withInstanceId();
+	expect(wkSpy).toBeCalledTimes(1);
+});
+
 test("withFunction", () => {
 	const wkFn: Function = () => { return true; };
 	const wkSpy = jest.spyOn(builder, 'withFunction');

--- a/test/argument/InstanceIdArgumentResolver.spec.ts
+++ b/test/argument/InstanceIdArgumentResolver.spec.ts
@@ -1,0 +1,24 @@
+import { mock, instance, when, reset, spy, verify } from "ts-mockito";
+import Module from "module/Module";
+import ModuleImpl from "module/ModuleImpl";
+import InstanceIdArgumentResolver from "argument/InstanceIdArgumentResolver";
+import { IllegalArgumentError } from "error/Errors";
+
+let wkModule: Module;
+
+beforeAll(() => {
+	const mockMod: ModuleImpl = mock(ModuleImpl);
+	wkModule = instance(mockMod);
+});
+
+test("specimen is whole", () => {
+	const specimen: InstanceIdArgumentResolver = new InstanceIdArgumentResolver();
+	expect(specimen).not.toBeNull();
+});
+
+test("resolve item", () => {
+	const specimen: InstanceIdArgumentResolver = new InstanceIdArgumentResolver();
+	const id: string = specimen.resolve(wkModule);
+	expect(id).not.toBeNull();
+	expect(id).toEqual("0-0-0");
+});


### PR DESCRIPTION
Access to Cydran instance id's only through the ArgumentsResolver to facilitate integration of outside pieces with Cydran.  Not intended as an ID generation facility for permanent/entity id