### PR TITLE
Support for the c-series element, related API support and inclusion of a fixed top and bottom series on stage component

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
 		"validate": "npx lerna run validate",
 		"test": "npx lerna run test",
 		"build": "npx lerna run build",
+		"rebuild": "npm run clean && npm run build",
 		"package": "npx lerna run package",
 		"install": "npx lerna exec --concurrency=1 -- npm install",
 		"clean-install": "npx lerna exec --concurrency=1 -- npm ci"

--- a/packages/cydran/src/CydranConstants.ts
+++ b/packages/cydran/src/CydranConstants.ts
@@ -69,7 +69,8 @@ enum TagNames {
 	SCRIPT = "script",
 	TEMPLATE = "template",
 	CYDRAN_REGION = "c-region",
-	CYDRAN_COMPONENT_STYLES = "c-component-styles"
+	CYDRAN_COMPONENT_STYLES = "c-component-styles",
+	CYDRAN_SERIES = "c-series"
 }
 
 const JSType = {

--- a/packages/cydran/src/CydranConstants.ts
+++ b/packages/cydran/src/CydranConstants.ts
@@ -148,6 +148,7 @@ const CONTEXT_NAME: RegExp = new RegExp(`^${CONTEXT_NAME_PARTIAL.source}$`);
 const OBJECT_ID: RegExp = new RegExp(`^${OBJECT_ID_PARTIAL.source}$`);
 const SCOPE_KEY: RegExp = ALPHA_NUMERIC_FULL;
 const REGION_NAME: RegExp = ALPHA_NUMERIC_FULL;
+const SERIES_NAME: RegExp = ALPHA_NUMERIC_FULL;
 const PROPERTY_SEGMENT: RegExp = /[a-zA-Z0-9]*/;
 const PROPERTY_DELIMITER: RegExp = new RegExp(`(${PERIOD.source}|${DASH.source})`);
 const PROPERTY_KEY: RegExp = new RegExp(`^${PROPERTY_SEGMENT.source}(${PROPERTY_DELIMITER.source}${PROPERTY_SEGMENT.source})*$`);
@@ -241,6 +242,7 @@ export {
 	OBJECT_ID,
 	SCOPE_KEY,
 	REGION_NAME,
+	SERIES_NAME,
 	PROPERTY_KEY,
 	RELATIVE_CONTEXT_PATH,
 	LITERAL_CONTEXT_PATH,

--- a/packages/cydran/src/CydranConstants.ts
+++ b/packages/cydran/src/CydranConstants.ts
@@ -204,6 +204,11 @@ const DEFAULT_PROPERTIES_VALUES = {
 	[`${ PropertyKeys.CYDRAN_STRICT_MESSAGE }`]: "Additional overhead due to enhanced validation, constraint checks, and dev tools WILL occur. Features are NOT restricted by mode or license."
 } as const;
 
+enum StageComponentSeries {
+	TOP = "top",
+	BOTTOM = "bottom"
+}
+
 export {
 	ANONYMOUS_REGION_PREFIX,
 	ATTRIBUTE_DELIMITER,
@@ -229,6 +234,7 @@ export {
 	INPUT_KEY,
 	INTERNAL_CHANNEL_NAME,
 	Ids,
+	StageComponentSeries,
 	To,
 	JSType,
 	PropertyKeys,

--- a/packages/cydran/src/behavior/core/SeriesBehavior.ts
+++ b/packages/cydran/src/behavior/core/SeriesBehavior.ts
@@ -6,7 +6,7 @@ import AbstractContainerBehavior from "behavior/AbstractContainerBehavior";
 import DigestableSource from "behavior/DigestableSource";
 import { Nestable } from "context/Context";
 import Series from "component/Series";
-import { isDefined, requireNotNull, defaultAsNull, removeFromArray } from 'util/Utils';
+import { isDefined, requireNotNull } from 'util/Utils';
 import DomUtils from "dom/DomUtils";
 import SeriesAttributes from "behavior/core/series/SeriesAttributes";
 import { validateValidSeriesName } from "validator/Validations";
@@ -61,10 +61,15 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public getAt<N extends Nestable>(index: number): N {
+		requireNotNull(index, "index");
+
 		return this.indexWithinBounds(index) ? this.components[index]  as N : null;
 	}
 
 	public replace(oldComponent: Nestable, newComponent: Nestable): void {
+		requireNotNull(oldComponent, "oldComponent");
+		requireNotNull(newComponent, "newComponent");
+
 		this.guardDuplicate(newComponent);
 		const index: number = this.components.indexOf(oldComponent);
 
@@ -74,6 +79,8 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public replaceAt(index: number, component: Nestable): void {
+		requireNotNull(index, "index");
+		requireNotNull(component, "component");
 		this.guardDuplicate(component);
 
 		if (this.indexWithinBounds(index)) {
@@ -89,6 +96,8 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public remove(component: Nestable): void {
+		requireNotNull(component, "component");
+
 		const index: number = this.components.indexOf(component);
 
 		if (index > -1) {
@@ -97,6 +106,8 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public removeAt(index: number): void {
+		requireNotNull(index, "index");
+
 		const component: Nestable = this.getAt(index);
 
 		if (isDefined(component)) {
@@ -108,7 +119,10 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public insertBefore(index: number, component: Nestable): void {
+		requireNotNull(index, "index");
+		requireNotNull(component, "component");
 		this.guardDuplicate(component);
+
 		const existingComponent: Nestable = this.getAt(index);
 
 		if (isDefined(existingComponent)) {
@@ -123,7 +137,10 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public insertAfter(index: number, component: Nestable): void {
+		requireNotNull(index, "index");
+		requireNotNull(component, "component");
 		this.guardDuplicate(component);
+
 		const existingComponent: Nestable = this.getAt(index);
 
 		if (isDefined(existingComponent)) {
@@ -136,6 +153,7 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public insertFirst(component: Nestable): void {
+		requireNotNull(component, "component");
 		this.guardDuplicate(component);
 
 		if (this.components.length > 0) {
@@ -149,7 +167,9 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public insertLast(component: Nestable): void {
+		requireNotNull(component, "component");
 		this.guardDuplicate(component);
+
 		const newEl: HTMLElement = component.$c().getEl();
 		this.topComment.parentElement.insertBefore(newEl, this.bottomComment);
 		this.components.push(component);
@@ -157,7 +177,7 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public contains(component: Nestable): boolean {
-		return this.components.indexOf(component) > -1;
+		return isDefined(component) && this.components.indexOf(component) > -1;
 	}
 
 	public tellComponents(name: string, payload: any): void {

--- a/packages/cydran/src/behavior/core/SeriesBehavior.ts
+++ b/packages/cydran/src/behavior/core/SeriesBehavior.ts
@@ -61,7 +61,7 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public getAt<N extends Nestable>(index: number): N {
-		return defaultAsNull(this.components[index]) as N;
+		return this.indexWithinBounds(index) ? this.components[index]  as N : null;
 	}
 
 	public replace(oldComponent: Nestable, newComponent: Nestable): void {

--- a/packages/cydran/src/behavior/core/SeriesBehavior.ts
+++ b/packages/cydran/src/behavior/core/SeriesBehavior.ts
@@ -1,0 +1,117 @@
+import Tellable from "interface/ables/Tellable";
+import ElementReference from "component/ElementReference";
+import ComponentInternals from "component/ComponentInternals";
+import BehaviorDependencies from "behavior/BehaviorDependencies";
+import AbstractContainerBehavior from "behavior/AbstractContainerBehavior";
+import DigestableSource from "behavior/DigestableSource";
+import { Nestable } from "context/Context";
+import Series from "component/Series";
+import { requireNotNull } from "util/Utils";
+import DomUtils from "dom/DomUtils";
+import SeriesAttributes from "behavior/core/series/SeriesAttributes";
+import { validateValidSeriesName } from "validator/Validations";
+
+// TODO - Update this to actually implement the Series interface correctly
+
+const COMMENT_TEXT: string = "Series";
+
+const DEFAULT_ATTRIBUTES: SeriesAttributes = {
+	name: null
+};
+
+class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesAttributes> implements Series, Tellable {
+
+	private components: Nestable[];
+
+	private parent: ComponentInternals;
+
+	private name: string;
+
+	private element: Comment;
+
+	private elements: ElementReference<HTMLElement>[];
+
+	public dependencies: BehaviorDependencies;
+
+	constructor(parent: ComponentInternals) {
+		super();
+		this.components = [];
+		this.elements = [];
+		this.parent = parent;
+		this.setDefaults(DEFAULT_ATTRIBUTES);
+		this.setValidations({
+			name: [validateValidSeriesName]
+		});
+		this.setConverters({});
+		this.setDefaultExpression("");
+		this.setPrefixed(false);
+	}
+
+	public isEmpty(): boolean {
+		return this.components.length === 0;
+	}
+
+	public clear(): void {
+		throw new Error("Method not implemented.");
+	}
+
+	public getAt<N extends Nestable>(index: number): N {
+		throw new Error("Method not implemented.");
+	}
+
+	public replaceAt(index: number, component: Nestable): void {
+		throw new Error("Method not implemented.");
+	}
+
+	public removeAt(index: number): void {
+		throw new Error("Method not implemented.");
+	}
+
+	public addAt(index: number, component: Nestable): void {
+		throw new Error("Method not implemented.");
+	}
+
+	public addAtEnd(component: Nestable): void {
+		throw new Error("Method not implemented.");
+	}
+
+	public tellComponents(name: string, payload: any): void {
+		for (const component of this.components) {
+			component.$c().tell(name, payload);
+		}
+	}
+
+	public messageComponents(channelName: string, messageName: string, payload: any): void {
+		for (const component of this.components) {
+			component.$c().send(messageName, payload).onChannel(channelName).toSelf();
+		}
+	}
+
+	public hasComponents(): boolean {
+		return this.components.length > 0;
+	}
+
+	public onInit(dependencies: BehaviorDependencies): void {
+		this.dependencies = dependencies;
+		this.element = DomUtils.createComment(COMMENT_TEXT);
+		this.dependencies.el.parentElement.replaceChild(this.element, this.dependencies.el);
+		this.name = requireNotNull(this.getParams().name, "name");
+		this.setLoggerName(`Series ${this.name} for ${dependencies.parent.getId()}`);
+		this.dependencies.parent.addSeries(this.name, this);
+	}
+
+	public onMount(): void {
+		// Intentionally do nothing
+	}
+
+	public requestDigestionSources(sources: DigestableSource[]): void {
+		// Intentionally do nothing
+	}
+
+	public $release() {
+		// this.setComponent(null);
+	}
+
+}
+
+export default SeriesBehavior;

--- a/packages/cydran/src/behavior/core/SeriesBehavior.ts
+++ b/packages/cydran/src/behavior/core/SeriesBehavior.ts
@@ -13,8 +13,8 @@ import { validateValidSeriesName } from "validator/Validations";
 import { DuplicateComponentError } from "error/Errors";
 import ComponentTransitions from "component/ComponentTransitions";
 
-const TOP_COMMENT_TEXT: string = "Series Start";
-const BOTTOM_COMMENT_TEXT: string = "Series End";
+const TOP_COMMENT_TEXT: string = "SS";
+const BOTTOM_COMMENT_TEXT: string = "SE";
 
 const DEFAULT_ATTRIBUTES: SeriesAttributes = {
 	name: null

--- a/packages/cydran/src/behavior/core/SeriesBehavior.ts
+++ b/packages/cydran/src/behavior/core/SeriesBehavior.ts
@@ -6,7 +6,7 @@ import AbstractContainerBehavior from "behavior/AbstractContainerBehavior";
 import DigestableSource from "behavior/DigestableSource";
 import { Nestable } from "context/Context";
 import Series from "component/Series";
-import { requireNotNull } from "util/Utils";
+import { isDefined, requireNotNull } from "util/Utils";
 import DomUtils from "dom/DomUtils";
 import SeriesAttributes from "behavior/core/series/SeriesAttributes";
 import { validateValidSeriesName } from "validator/Validations";
@@ -52,28 +52,49 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public clear(): void {
-		throw new Error("Method not implemented.");
+		while (this.hasComponents()) {
+			this.removeAt(0);
+		}
 	}
 
+	// -----------------------------------------------------------------------
+
 	public getAt<N extends Nestable>(index: number): N {
-		throw new Error("Method not implemented.");
+		return this.components[index] as N;
 	}
 
 	public replaceAt(index: number, component: Nestable): void {
 		throw new Error("Method not implemented.");
 	}
 
-	public removeAt(index: number): void {
+	public remove(component: Nestable): void {
 		throw new Error("Method not implemented.");
+	}
+
+	public removeAt(index: number): void {
+		// TODO - This is not correct; implememnt properly
+		const component: Nestable = this.getAt(index);
+
+		if (isDefined(component)) {
+			const el: HTMLElement = component.$c().getEl();
+
+			this.components.splice(index, 1);
+		}
 	}
 
 	public addAt(index: number, component: Nestable): void {
 		throw new Error("Method not implemented.");
 	}
 
-	public addAtEnd(component: Nestable): void {
+	public addAsFirst(component: Nestable): void {
 		throw new Error("Method not implemented.");
 	}
+
+	public addAsLast(component: Nestable): void {
+		throw new Error("Method not implemented.");
+	}
+
+	// -----------------------------------------------------------------------
 
 	public tellComponents(name: string, payload: any): void {
 		for (const component of this.components) {
@@ -109,7 +130,7 @@ class SeriesBehavior extends AbstractContainerBehavior<any, HTMLElement, SeriesA
 	}
 
 	public $release() {
-		// this.setComponent(null);
+		this.clear();
 	}
 
 }

--- a/packages/cydran/src/behavior/core/series/SeriesAttributes.ts
+++ b/packages/cydran/src/behavior/core/series/SeriesAttributes.ts
@@ -1,0 +1,7 @@
+interface SeriesAttributes {
+
+	name: string;
+
+}
+
+export default SeriesAttributes;

--- a/packages/cydran/src/component/ComponentInternals.ts
+++ b/packages/cydran/src/component/ComponentInternals.ts
@@ -13,8 +13,9 @@ import { FilterBuilder } from "filter/Filter";
 import Watchable from "interface/ables/Watchable";
 import Actionable from "interface/ables/Actionable";
 import Sendable from "interface/ables/Sendable";
-import { ActionContinuation, Context, Nestable } from "context/Context";
+import { ActionContinuation, Context, Nestable, SeriesOperations } from "context/Context";
 import Receivable from "interface/ables/Receivable";
+import Series from "component/Series";
 
 interface ComponentInternals extends Digestable, Tellable, DigestableSource, Actionable<ActionContinuation>, Sendable, Receivable {
 
@@ -28,6 +29,8 @@ interface ComponentInternals extends Digestable, Tellable, DigestableSource, Act
 
 	addRegion(name: string, region: Region): Region;
 
+	addSeries(name: string, series: Series): Series;
+
 	createRegionName(): string;
 
 	digest(): void;
@@ -35,6 +38,8 @@ interface ComponentInternals extends Digestable, Tellable, DigestableSource, Act
 	evaluate<T>(expression: string): T;
 
 	forElement<E extends HTMLElement>(name: string): ElementOperations<E>;
+
+	forSeries(name: string): SeriesOperations;
 
 	forForm(name: string): FormOperations;
 

--- a/packages/cydran/src/component/MvvmDomWalkerImpl.ts
+++ b/packages/cydran/src/component/MvvmDomWalkerImpl.ts
@@ -5,14 +5,15 @@ import ComponentStylesVisitor from "component/visitor/ComponentStylesVisitor";
 import RegionVisitor from 'component/visitor/RegionVisitor';
 import OtherVisitor from "component/visitor/OtherVisitor";
 import TextVisitor from "component/visitor/TextVisitor";
-import Logger from "log/Logger";
+import SeriesVisitor from "component/visitor/SeriesVisitor";
 
 class MvvmDomWalkerImpl extends DomWalkerImpl<ComponentInternals> {
 
-	constructor(textVisitor: TextVisitor, otherVisitor: OtherVisitor, logger: Logger) {
+	constructor(textVisitor: TextVisitor, otherVisitor: OtherVisitor) {
 		super(otherVisitor, textVisitor, new NonOpVisitor());
 		this.addVisitor("c-component-styles", new ComponentStylesVisitor());
-		this.addVisitor("c-region", new RegionVisitor(logger));
+		this.addVisitor("c-region", new RegionVisitor());
+		this.addVisitor("c-series", new SeriesVisitor());
 	}
 
 }

--- a/packages/cydran/src/component/MvvmDomWalkerImpl.ts
+++ b/packages/cydran/src/component/MvvmDomWalkerImpl.ts
@@ -6,14 +6,15 @@ import RegionVisitor from 'component/visitor/RegionVisitor';
 import OtherVisitor from "component/visitor/OtherVisitor";
 import TextVisitor from "component/visitor/TextVisitor";
 import SeriesVisitor from "component/visitor/SeriesVisitor";
+import { TagNames } from "CydranConstants";
 
 class MvvmDomWalkerImpl extends DomWalkerImpl<ComponentInternals> {
 
 	constructor(textVisitor: TextVisitor, otherVisitor: OtherVisitor) {
 		super(otherVisitor, textVisitor, new NonOpVisitor());
-		this.addVisitor("c-component-styles", new ComponentStylesVisitor());
-		this.addVisitor("c-region", new RegionVisitor());
-		this.addVisitor("c-series", new SeriesVisitor());
+		this.addVisitor(TagNames.CYDRAN_COMPONENT_STYLES, new ComponentStylesVisitor());
+		this.addVisitor(TagNames.CYDRAN_REGION, new RegionVisitor());
+		this.addVisitor(TagNames.CYDRAN_SERIES, new SeriesVisitor());
 	}
 
 }

--- a/packages/cydran/src/component/Series.ts
+++ b/packages/cydran/src/component/Series.ts
@@ -1,0 +1,27 @@
+import { Nestable } from "context/Context";
+
+interface Series {
+
+	getAt<N extends Nestable>(index: number): N;
+
+	replaceAt(index: number, component: Nestable): void;
+
+	removeAt(index: number): void;
+
+	addAt(index: number, component: Nestable): void;
+
+	addAtEnd(component: Nestable): void;
+
+	tellComponents(name: string, payload: any): void;
+
+	messageComponents(channelName: string, messageName: string, payload: any): void;
+
+	hasComponents(): boolean;
+
+	isEmpty(): boolean;
+
+	clear(): void;
+
+}
+
+export default Series;

--- a/packages/cydran/src/component/Series.ts
+++ b/packages/cydran/src/component/Series.ts
@@ -6,11 +6,15 @@ interface Series {
 
 	replaceAt(index: number, component: Nestable): void;
 
+	remove(component: Nestable): void;
+
 	removeAt(index: number): void;
 
 	addAt(index: number, component: Nestable): void;
 
-	addAtEnd(component: Nestable): void;
+	addAsFirst(component: Nestable): void;
+
+	addAsLast(component: Nestable): void;
 
 	tellComponents(name: string, payload: any): void;
 

--- a/packages/cydran/src/component/Series.ts
+++ b/packages/cydran/src/component/Series.ts
@@ -4,23 +4,29 @@ interface Series {
 
 	getAt<N extends Nestable>(index: number): N;
 
+	replace(oldComponent: Nestable, newComponent: Nestable): void;
+
 	replaceAt(index: number, component: Nestable): void;
 
 	remove(component: Nestable): void;
 
 	removeAt(index: number): void;
 
-	addAt(index: number, component: Nestable): void;
+	insertBefore(index: number, component: Nestable): void;
 
-	addAsFirst(component: Nestable): void;
+	insertAfter(index: number, component: Nestable): void;
 
-	addAsLast(component: Nestable): void;
+	insertFirst(component: Nestable): void;
+
+	insertLast(component: Nestable): void;
 
 	tellComponents(name: string, payload: any): void;
 
 	messageComponents(channelName: string, messageName: string, payload: any): void;
 
 	hasComponents(): boolean;
+
+	contains(component: Nestable): boolean;
 
 	isEmpty(): boolean;
 

--- a/packages/cydran/src/component/SeriesOperationsImpl.ts
+++ b/packages/cydran/src/component/SeriesOperationsImpl.ts
@@ -1,0 +1,47 @@
+import { Nestable, SeriesOperations } from 'context/Context';
+import Series from 'component/Series';
+import { requireNotNull } from 'util/Utils';
+
+class SeriesOperationsImpl implements SeriesOperations {
+
+	private series: Series
+
+	constructor(series: Series) {
+		this.series = requireNotNull(series, "series");
+	}
+
+	public getAt<N extends Nestable>(index: number): N {
+		return this.series.getAt(index);
+	}
+
+	public replaceAt(index: number, component: Nestable): void {
+		this.series.replaceAt(index, component);
+	}
+
+	public removeAt(index: number): void {
+		this.series.removeAt(index);
+	}
+
+	public addAt(index: number, component: Nestable): void {
+		this.series.addAt(index, component);
+	}
+
+	public addAtEnd(component: Nestable): void {
+		this.series.addAtEnd(component);
+	}
+
+	public hasComponents(): boolean {
+		return this.series.hasComponents();
+	}
+
+	public isEmpty(): boolean {
+		return this.series.isEmpty();
+	}
+
+	public clear(): void {
+		this.series.clear();
+	}
+
+}
+
+export default SeriesOperationsImpl;

--- a/packages/cydran/src/component/SeriesOperationsImpl.ts
+++ b/packages/cydran/src/component/SeriesOperationsImpl.ts
@@ -10,6 +10,26 @@ class SeriesOperationsImpl implements SeriesOperations {
 		this.series = requireNotNull(series, "series");
 	}
 
+	public replace(oldComponent: Nestable, newComponent: Nestable): void {
+		this.series.replace(oldComponent, newComponent);
+	}
+
+	public insertBefore(index: number, component: Nestable): void {
+		this.series.insertBefore(index, component);
+	}
+
+	public insertAfter(index: number, component: Nestable): void {
+		this.series.insertAfter(index, component);
+	}
+
+	public insertFirst(component: Nestable): void {
+		this.series.insertFirst(component);
+	}
+
+	public insertLast(component: Nestable): void {
+		this.series.insertLast(component);
+	}
+
 	public getAt<N extends Nestable>(index: number): N {
 		return this.series.getAt(index);
 	}
@@ -26,20 +46,12 @@ class SeriesOperationsImpl implements SeriesOperations {
 		this.series.removeAt(index);
 	}
 
-	public addAt(index: number, component: Nestable): void {
-		this.series.addAt(index, component);
-	}
-
-	public addAsFirst(component: Nestable): void {
-		this.series.addAsFirst(component);
-	}
-
-	public addAsLast(component: Nestable): void {
-		this.series.addAsLast(component);
-	}
-
 	public hasComponents(): boolean {
 		return this.series.hasComponents();
+	}
+
+	public contains(component: Nestable): boolean {
+		return this.series.contains(component);
 	}
 
 	public isEmpty(): boolean {

--- a/packages/cydran/src/component/SeriesOperationsImpl.ts
+++ b/packages/cydran/src/component/SeriesOperationsImpl.ts
@@ -18,6 +18,10 @@ class SeriesOperationsImpl implements SeriesOperations {
 		this.series.replaceAt(index, component);
 	}
 
+	public remove(component: Nestable): void {
+		this.series.remove(component);
+	}
+
 	public removeAt(index: number): void {
 		this.series.removeAt(index);
 	}
@@ -26,8 +30,12 @@ class SeriesOperationsImpl implements SeriesOperations {
 		this.series.addAt(index, component);
 	}
 
-	public addAtEnd(component: Nestable): void {
-		this.series.addAtEnd(component);
+	public addAsFirst(component: Nestable): void {
+		this.series.addAsFirst(component);
+	}
+
+	public addAsLast(component: Nestable): void {
+		this.series.addAsLast(component);
 	}
 
 	public hasComponents(): boolean {

--- a/packages/cydran/src/component/renderer/StageRendererImpl.ts
+++ b/packages/cydran/src/component/renderer/StageRendererImpl.ts
@@ -3,6 +3,7 @@ import ComponentIdPair from "component/CompnentIdPair";
 import { SelectorError } from "error/Errors";
 import { Attrs, TagNames, ATTRIBUTE_DELIMITER, DEFAULT_PREFIX, STAGE_BODY_REGION_NAME } from "CydranConstants";
 import DomUtils from "dom/DomUtils";
+import SeriesElement from "element/SeriesElement";
 
 const CYDRAN_PREFIX: string = DEFAULT_PREFIX + ATTRIBUTE_DELIMITER;
 
@@ -41,6 +42,10 @@ class StageRendererImpl implements Renderer {
 			element.appendChild(componentDiv);
 		}
 
+		const topSeries: SeriesElement = DomUtils.createElement(TagNames.CYDRAN_SERIES);
+		topSeries.setAttribute(Attrs.NAME, "top");
+		element.appendChild(topSeries);
+
 		const regionDiv: HTMLElement = DomUtils.createElement(TagNames.CYDRAN_REGION);
 		regionDiv.setAttribute(Attrs.NAME, STAGE_BODY_REGION_NAME);
 		element.appendChild(regionDiv);
@@ -49,6 +54,10 @@ class StageRendererImpl implements Renderer {
 			const componentDiv: HTMLElement = this.cydranScriptElement(pair);
 			element.appendChild(componentDiv);
 		}
+
+		const bottomSeries: SeriesElement = DomUtils.createElement(TagNames.CYDRAN_SERIES);
+		bottomSeries.setAttribute(Attrs.NAME, "bottom");
+		element.appendChild(bottomSeries);
 
 		return element;
 	}

--- a/packages/cydran/src/component/renderer/StageRendererImpl.ts
+++ b/packages/cydran/src/component/renderer/StageRendererImpl.ts
@@ -1,6 +1,6 @@
 import Renderer from "component/Renderer";
 import { SelectorError } from "error/Errors";
-import { Attrs, TagNames, ATTRIBUTE_DELIMITER, DEFAULT_PREFIX, STAGE_BODY_REGION_NAME } from "CydranConstants";
+import { Attrs, TagNames, ATTRIBUTE_DELIMITER, DEFAULT_PREFIX, STAGE_BODY_REGION_NAME, StageComponentSeries } from "CydranConstants";
 import DomUtils from "dom/DomUtils";
 import SeriesElement from "element/SeriesElement";
 import { requireNotNull } from 'util/Utils';
@@ -31,7 +31,7 @@ class StageRendererImpl implements Renderer {
 		}
 
 		const topSeries: SeriesElement = DomUtils.createElement(TagNames.CYDRAN_SERIES);
-		topSeries.setAttribute(Attrs.NAME, "top");
+		topSeries.setAttribute(Attrs.NAME, StageComponentSeries.TOP);
 		element.appendChild(topSeries);
 
 		const regionDiv: HTMLElement = DomUtils.createElement(TagNames.CYDRAN_REGION);
@@ -39,7 +39,7 @@ class StageRendererImpl implements Renderer {
 		element.appendChild(regionDiv);
 
 		const bottomSeries: SeriesElement = DomUtils.createElement(TagNames.CYDRAN_SERIES);
-		bottomSeries.setAttribute(Attrs.NAME, "bottom");
+		bottomSeries.setAttribute(Attrs.NAME, StageComponentSeries.BOTTOM);
 		element.appendChild(bottomSeries);
 
 		return element;

--- a/packages/cydran/src/component/renderer/StageRendererImpl.ts
+++ b/packages/cydran/src/component/renderer/StageRendererImpl.ts
@@ -11,6 +11,7 @@ class StageRendererImpl implements Renderer {
 
 	private selector: string;
 
+	// TODO - remove these ids as soon as the series support is fully in place
 	private topComponentIds: ComponentIdPair[];
 
 	private bottomComponentIds: ComponentIdPair[];

--- a/packages/cydran/src/component/renderer/StageRendererImpl.ts
+++ b/packages/cydran/src/component/renderer/StageRendererImpl.ts
@@ -1,9 +1,9 @@
 import Renderer from "component/Renderer";
-import ComponentIdPair from "component/CompnentIdPair";
 import { SelectorError } from "error/Errors";
 import { Attrs, TagNames, ATTRIBUTE_DELIMITER, DEFAULT_PREFIX, STAGE_BODY_REGION_NAME } from "CydranConstants";
 import DomUtils from "dom/DomUtils";
 import SeriesElement from "element/SeriesElement";
+import { requireNotNull } from 'util/Utils';
 
 const CYDRAN_PREFIX: string = DEFAULT_PREFIX + ATTRIBUTE_DELIMITER;
 
@@ -11,16 +11,8 @@ class StageRendererImpl implements Renderer {
 
 	private selector: string;
 
-	// TODO - remove these ids as soon as the series support is fully in place
-	private topComponentIds: ComponentIdPair[];
-
-	private bottomComponentIds: ComponentIdPair[];
-
-	// TODO - Replace the component id paradigm with a Component instance containers
-	constructor(selector: string, topComponentIds: ComponentIdPair[], bottomComponentIds: ComponentIdPair[]) {
-		this.selector = selector;
-		this.topComponentIds = topComponentIds;
-		this.bottomComponentIds = bottomComponentIds;
+	constructor(selector: string) {
+		this.selector = requireNotNull(selector, "selector");
 	}
 
 	public render(): HTMLElement {
@@ -38,11 +30,6 @@ class StageRendererImpl implements Renderer {
 			element.removeChild(element.firstChild);
 		}
 
-		for (const pair of this.topComponentIds) {
-			const componentDiv: HTMLElement = this.cydranScriptElement(pair);
-			element.appendChild(componentDiv);
-		}
-
 		const topSeries: SeriesElement = DomUtils.createElement(TagNames.CYDRAN_SERIES);
 		topSeries.setAttribute(Attrs.NAME, "top");
 		element.appendChild(topSeries);
@@ -51,23 +38,11 @@ class StageRendererImpl implements Renderer {
 		regionDiv.setAttribute(Attrs.NAME, STAGE_BODY_REGION_NAME);
 		element.appendChild(regionDiv);
 
-		for (const pair of this.bottomComponentIds) {
-			const componentDiv: HTMLElement = this.cydranScriptElement(pair);
-			element.appendChild(componentDiv);
-		}
-
 		const bottomSeries: SeriesElement = DomUtils.createElement(TagNames.CYDRAN_SERIES);
 		bottomSeries.setAttribute(Attrs.NAME, "bottom");
 		element.appendChild(bottomSeries);
 
 		return element;
-	}
-
-	private cydranScriptElement(pair: ComponentIdPair): HTMLElement {
-		const retval: HTMLElement = DomUtils.createElement(TagNames.CYDRAN_REGION);
-		retval.setAttribute(CYDRAN_PREFIX + "region" + ATTRIBUTE_DELIMITER + Attrs.COMPONENT, pair.componentId);
-		retval.setAttribute(CYDRAN_PREFIX + "region" + ATTRIBUTE_DELIMITER + Attrs.CONTEXT, pair.contextId);
-		return retval;
 	}
 }
 

--- a/packages/cydran/src/component/visitor/RegionVisitor.ts
+++ b/packages/cydran/src/component/visitor/RegionVisitor.ts
@@ -3,15 +3,8 @@ import RegionBehavior from "behavior/core/RegionBehavior";
 import BehaviorDependencies from "behavior/BehaviorDependencies";
 import BehaviorTransitions from "behavior/BehaviorTransitions";
 import RegionElement from 'element/RegionElement';
-import Logger from "log/Logger";
 
 class RegionVisitor implements ElementVisitor<RegionElement, any> {
-
-	private logger: Logger;
-
-	constructor(logger: Logger) {
-		this.logger = logger;
-	}
 
 	public visit(element: RegionElement, internals: any, consumer: (element: HTMLElement | Text | Comment) => void, topLevel: boolean): void {
 		const region: RegionBehavior = new RegionBehavior(internals);

--- a/packages/cydran/src/component/visitor/SeriesVisitor.ts
+++ b/packages/cydran/src/component/visitor/SeriesVisitor.ts
@@ -1,0 +1,28 @@
+import ElementVisitor from "component/visitor/ElementVisitor";
+import BehaviorDependencies from "behavior/BehaviorDependencies";
+import BehaviorTransitions from "behavior/BehaviorTransitions";
+import SeriesElement from "element/SeriesElement";
+import SeriesBehavior from "behavior/core/SeriesBehavior";
+
+class SeriesVisitor implements ElementVisitor<SeriesElement, any> {
+
+	public visit(element: SeriesElement, internals: any, consumer: (element: HTMLElement | Text | Comment) => void, topLevel: boolean): void {
+		const series: SeriesBehavior = new SeriesBehavior(internals);
+
+		const dependencies: BehaviorDependencies = {
+			parent: internals,
+			el: element,
+			expression: "",
+			model: internals.getModel(),
+			prefix: internals.getExtractor().getPrefix(),
+			behaviorPrefix: internals.getExtractor().asTypePrefix("series"),
+			validated: internals.isValidated(),
+			mutable: true
+		};
+
+		internals.addBehavior(series);
+		series.tell(BehaviorTransitions.INIT, dependencies);
+	}
+}
+
+export default SeriesVisitor;

--- a/packages/cydran/src/context/Context.ts
+++ b/packages/cydran/src/context/Context.ts
@@ -53,11 +53,15 @@ interface SeriesOperations {
 
 	replaceAt(index: number, component: Nestable): void;
 
+	remove(component: Nestable): void;
+
 	removeAt(index: number): void;
 
 	addAt(index: number, component: Nestable): void;
 
-	addAtEnd(component: Nestable): void;
+	addAsFirst(component: Nestable): void;
+
+	addAsLast(component: Nestable): void;
 
 	hasComponents(): boolean;
 

--- a/packages/cydran/src/context/Context.ts
+++ b/packages/cydran/src/context/Context.ts
@@ -46,6 +46,27 @@ interface RegionContinuation {
 
 }
 
+
+interface SeriesOperations {
+
+	getAt<N extends Nestable>(index: number): N;
+
+	replaceAt(index: number, component: Nestable): void;
+
+	removeAt(index: number): void;
+
+	addAt(index: number, component: Nestable): void;
+
+	addAtEnd(component: Nestable): void;
+
+	hasComponents(): boolean;
+
+	isEmpty(): boolean;
+
+	clear(): void;
+
+}
+
 interface ActionContinuation extends Tellable, Messagable, Watchable {
 
 	getParent(): Nestable;
@@ -90,6 +111,8 @@ interface ActionContinuation extends Tellable, Messagable, Watchable {
 	tell(name: string, payload?: any): void;
 
 	forElement<E extends HTMLElement>(name: string): ElementOperations<E>;
+
+	forSeries(name: string): SeriesOperations;
 
 	forForm(name: string): FormOperations;
 
@@ -200,4 +223,4 @@ interface Registry extends Register<Registry> {
 
 }
 
-export { Context, InternalContext, Stage, Nestable, RegionContinuation, ActionContinuation, Registry };
+export { Context, InternalContext, Stage, Nestable, RegionContinuation, ActionContinuation, Registry, SeriesOperations };

--- a/packages/cydran/src/context/Context.ts
+++ b/packages/cydran/src/context/Context.ts
@@ -51,19 +51,25 @@ interface SeriesOperations {
 
 	getAt<N extends Nestable>(index: number): N;
 
+	replace(oldComponent: Nestable, newComponent: Nestable): void;
+
 	replaceAt(index: number, component: Nestable): void;
 
 	remove(component: Nestable): void;
 
 	removeAt(index: number): void;
 
-	addAt(index: number, component: Nestable): void;
+	insertBefore(index: number, component: Nestable): void;
 
-	addAsFirst(component: Nestable): void;
+	insertAfter(index: number, component: Nestable): void;
 
-	addAsLast(component: Nestable): void;
+	insertFirst(component: Nestable): void;
+
+	insertLast(component: Nestable): void;
 
 	hasComponents(): boolean;
+
+	contains(component: Nestable): boolean;
 
 	isEmpty(): boolean;
 
@@ -202,9 +208,9 @@ interface Stage extends Releasable {
 
 	getContext(): Context;
 
-	addComponentBefore(component: Nestable): Stage;
+	before(): SeriesOperations;
 
-	addComponentAfter(component: Nestable): Stage;
+	after(): SeriesOperations;
 
 	start(): Stage;
 

--- a/packages/cydran/src/context/GlobalContextImpl.ts
+++ b/packages/cydran/src/context/GlobalContextImpl.ts
@@ -204,8 +204,8 @@ class GlobalContextImpl extends AbstractContextImpl<Context> implements GlobalCo
 
 		this.registerSingleton("cydran:textVisitor", TextVisitor);
 		this.registerSingleton("cydran:otherVisitor", OtherVisitor, argumentsBuilder().withContext().build());
-		this.registerSingleton("cydran:domWalker", MvvmDomWalkerImpl,
-		argumentsBuilder().with("cydran:textVisitor").with("cydran:otherVisitor").withLogger("Region").build());
+		this.registerSingleton("cydran:domWalker", MvvmDomWalkerImpl, argumentsBuilder().with("cydran:textVisitor")
+			.with("cydran:otherVisitor").build());
 	}
 
 }

--- a/packages/cydran/src/continuation/ActionContinuationImpl.ts
+++ b/packages/cydran/src/continuation/ActionContinuationImpl.ts
@@ -13,7 +13,7 @@ import MetadataContinuation from "component/MetadataContinuation";
 import SendContinuation from "continuation/SendContinuation";
 import SendContinuationImpl from 'continuation/SendContinuationImpl';
 import IntervalContinuationImpl from "continuation/IntervalContinuationImpl";
-import { ActionContinuation, Context, Nestable, RegionContinuation } from "context/Context";
+import { ActionContinuation, Context, Nestable, RegionContinuation, SeriesOperations } from "context/Context";
 
 class ActionContinuationImpl implements ActionContinuation {
 
@@ -52,6 +52,10 @@ class ActionContinuationImpl implements ActionContinuation {
 
 	public regions(): RegionContinuation {
 		return new RegionContinuationImpl(this.internals);
+	}
+
+	public forSeries(name: string): SeriesOperations {
+		return this.internals.forSeries(name);
 	}
 
 	public forElement<E extends HTMLElement>(name: string): ElementOperations<E> {

--- a/packages/cydran/src/element/ComponentStylesElement.ts
+++ b/packages/cydran/src/element/ComponentStylesElement.ts
@@ -2,7 +2,6 @@ class ComponentStylesElement extends HTMLElement {
 
 	constructor() {
 		super();
-		console.log("ComponentStylesElement webcomponent constructed");
 	}
 
 	public connectedCallback() {

--- a/packages/cydran/src/element/SeriesElement.ts
+++ b/packages/cydran/src/element/SeriesElement.ts
@@ -1,6 +1,6 @@
 import { isDefined } from "util/Utils";
 
-class RegionElement extends HTMLElement {
+class SeriesElement extends HTMLElement {
 
 	constructor() {
 		super();
@@ -23,4 +23,4 @@ class RegionElement extends HTMLElement {
 	}
 }
 
-export default RegionElement;
+export default SeriesElement;

--- a/packages/cydran/src/element/index.ts
+++ b/packages/cydran/src/element/index.ts
@@ -1,11 +1,15 @@
 import { isDefined } from "util/Utils";
-import RegionElement from 'element/RegionElement';
-import ComponentStylesElement from 'element/ComponentStylesElement';
+import RegionElement from "element/RegionElement";
+import ComponentStylesElement from "element/ComponentStylesElement";
+import Type from "interface/Type";
+import SeriesElement from "element/SeriesElement";
 
-if (!isDefined(customElements.get("c-region"))) {
-	customElements.define("c-region", RegionElement);
+function register<T extends HTMLElement>(tag: string, elClass: Type<T>) {
+	if (!isDefined(customElements.get(tag))) {
+		customElements.define(tag, elClass);
+	}
 }
 
-if (!isDefined(customElements.get("c-region"))) {
-	customElements.define("c-component-styles", ComponentStylesElement);
-}
+register("c-region", RegionElement);
+register("c-component-styles", ComponentStylesElement);
+register("c-series", SeriesElement);

--- a/packages/cydran/src/error/Errors.ts
+++ b/packages/cydran/src/error/Errors.ts
@@ -264,6 +264,12 @@ class PrefixMismatchError extends CydranError {
 
 }
 
+class DuplicateComponentError extends CydranError {
+	constructor(msg: string) {
+		super(msg);
+	}
+}
+
 export {
 	BehaviorError,
 	CydranError,
@@ -298,5 +304,6 @@ export {
 	ContextUnavailableError,
 	UnsupportedOperationError,
 	PathError,
-	PrefixMismatchError
+	PrefixMismatchError,
+	DuplicateComponentError
 };

--- a/packages/cydran/src/error/Errors.ts
+++ b/packages/cydran/src/error/Errors.ts
@@ -265,9 +265,19 @@ class PrefixMismatchError extends CydranError {
 }
 
 class DuplicateComponentError extends CydranError {
+
 	constructor(msg: string) {
 		super(msg);
 	}
+
+}
+
+class BoundsError extends CydranError {
+
+	constructor(msg: string) {
+		super(msg);
+	}
+
 }
 
 export {
@@ -305,5 +315,6 @@ export {
 	UnsupportedOperationError,
 	PathError,
 	PrefixMismatchError,
-	DuplicateComponentError
+	DuplicateComponentError,
+	BoundsError
 };

--- a/packages/cydran/src/stage/StageImpl.ts
+++ b/packages/cydran/src/stage/StageImpl.ts
@@ -1,5 +1,5 @@
 import SimpleMap from "interface/SimpleMap";
-import { Context, Nestable, Stage } from "context/Context";
+import { Context, Nestable, SeriesOperations, Stage } from "context/Context";
 import StageInternals from "stage/StageInternals";
 import { defaulted, requireNotNull } from "util/Utils";
 import GlobalContextHolder from "context/GlobalContextHolder";
@@ -20,20 +20,6 @@ class StageImpl implements Stage {
 
 	public getContext(): Context {
 		return this.internals.getContext();
-	}
-
-	public addComponentBefore(component: Nestable): Stage {
-		// TODO - Replace this method with component lists
-		this.internals.addComponentBefore(component);
-
-		return this;
-	}
-
-	public addComponentAfter(component: Nestable): Stage {
-		// TODO - Replace this method with component lists
-		this.internals.addComponentAfter(component);
-
-		return this;
 	}
 
 	public start(): Stage {
@@ -66,6 +52,14 @@ class StageImpl implements Stage {
 
 	public isStarted(): boolean {
 		return this.internals.isStarted();
+	}
+
+	public before(): SeriesOperations {
+		return this.internals.before();
+	}
+
+	public after(): SeriesOperations {
+		return this.internals.after();
 	}
 
 }

--- a/packages/cydran/src/stage/StageInternals.ts
+++ b/packages/cydran/src/stage/StageInternals.ts
@@ -1,4 +1,4 @@
-import { Context, Nestable, Stage } from "context/Context";
+import { Context, Nestable, SeriesOperations, Stage } from "context/Context";
 import Releasable from "interface/ables/Releasable";
 
 interface StageInternals extends Releasable {
@@ -18,6 +18,10 @@ interface StageInternals extends Releasable {
 	addInitializer(thisObject: any, callback: (stage: Stage) => void): void;
 
 	isStarted(): boolean;
+
+	before(): SeriesOperations;
+
+	after(): SeriesOperations;
 
 }
 

--- a/packages/cydran/src/stage/StageInternalsImpl.ts
+++ b/packages/cydran/src/stage/StageInternalsImpl.ts
@@ -1,4 +1,4 @@
-import { Context, Nestable } from 'context/Context';
+import { Context, Nestable, SeriesOperations } from 'context/Context';
 import StageInternals from 'stage/StageInternals';
 import Stage from 'stage/StageImpl';
 import { defaulted, extractClassName, isDefined, requireNotNull } from 'util/Utils';
@@ -7,7 +7,7 @@ import ComponentIdPair from 'component/CompnentIdPair';
 import MachineState from 'machine/MachineState';
 import Logger from 'log/Logger';
 import SimpleMap from 'interface/SimpleMap';
-import { CydranMode, PropertyKeys, Ids, STAGE_BODY_REGION_NAME, CYDRAN_PUBLIC_CHANNEL, Events, To } from 'CydranConstants';
+import { CydranMode, PropertyKeys, Ids, STAGE_BODY_REGION_NAME, CYDRAN_PUBLIC_CHANNEL, Events, To, StageComponentSeries } from 'CydranConstants';
 import ContextTransitions from 'component/ContextTransitions';
 import ContextStates from 'component/ContextStates';
 import DomUtils from 'dom/DomUtils';
@@ -52,6 +52,14 @@ class StageInternalsImpl implements StageInternals {
 		this.logger = this.context.getObject("logger", Ids.STAGE_INTERNALS);
 		this.root = null;
 		this.transitionTo(ContextTransitions.BOOTSTRAP);
+	}
+
+	public before(): SeriesOperations {
+		return this.root.$c().forSeries(StageComponentSeries.TOP);
+	}
+
+	public after(): SeriesOperations {
+		return this.root.$c().forSeries(StageComponentSeries.BOTTOM);
 	}
 
 	public getContext(): Context {

--- a/packages/cydran/src/stage/StageInternalsImpl.ts
+++ b/packages/cydran/src/stage/StageInternalsImpl.ts
@@ -27,10 +27,6 @@ class StageInternalsImpl implements StageInternals {
 
 	private root: Component;
 
-	private topComponentIds: ComponentIdPair[];
-
-	private bottomComponentIds: ComponentIdPair[];
-
 	private machineState: MachineState<StageInternalsImpl>;
 
 	private context: Context;
@@ -46,8 +42,6 @@ class StageInternalsImpl implements StageInternals {
 		this.stage = requireNotNull(stage, "stage");
 		this.rootSelector = requireNotNull(rootSelector, "rootSelector");
 		this.initializers = new InitializersImpl<Stage>();
-		this.topComponentIds = [];
-		this.bottomComponentIds = [];
 		this.machineState = CONTEXT_MACHINE.create(this);
 
 		if (isDefined(callback)) {
@@ -128,7 +122,7 @@ class StageInternalsImpl implements StageInternals {
 
 	public onDomReady(): void {
 		this.logger.ifDebug(() => "DOM Ready");
-		const renderer: Renderer = new StageRendererImpl(this.rootSelector, this.topComponentIds, this.bottomComponentIds);
+		const renderer: Renderer = new StageRendererImpl(this.rootSelector);
 		this.root = this.getContext().getObject(Ids.STAGE_COMPONENT, renderer);
 		this.root.$c().tell("setParent", null);
 		this.root.$c().tell(ComponentTransitions.INIT);

--- a/packages/cydran/src/stage/StageInternalsImpl.ts
+++ b/packages/cydran/src/stage/StageInternalsImpl.ts
@@ -49,6 +49,12 @@ class StageInternalsImpl implements StageInternals {
 		}
 
 		this.context.getProperties().load(defaulted(properties, {}));
+
+		if (this.context.getProperties().includes(PropertyKeys.CYDRAN_OVERRIDE_WINDOW)) {
+			const overrideWindow: Window = this.context.getProperties().get(PropertyKeys.CYDRAN_OVERRIDE_WINDOW);
+			DomUtils.setWindow(overrideWindow);
+		}
+		
 		this.logger = this.context.getObject("logger", Ids.STAGE_INTERNALS);
 		this.root = null;
 		this.transitionTo(ContextTransitions.BOOTSTRAP);

--- a/packages/cydran/src/validator/Validations.ts
+++ b/packages/cydran/src/validator/Validations.ts
@@ -1,4 +1,4 @@
-import { REGION_NAME, OBJECT_ID, CONTEXT_NAME, REQUESTABLE_OBJECT_PATH } from 'CydranConstants';
+import { REGION_NAME, OBJECT_ID, CONTEXT_NAME, REQUESTABLE_OBJECT_PATH, SERIES_NAME } from 'CydranConstants';
 import { isDefined } from 'util/Utils';
 import { Predicate } from 'interface/Predicate';
 import { asString } from "util/AsFunctions";
@@ -8,6 +8,9 @@ const validateDefined: (value: any, instance: any, state: any) => string =
 
 const validateValidRegionName: (value: any, instance: any, state: any) => string =
 	(value: any, instance: any, state: any) => !isDefined(value) || REGION_NAME.test(value) ? null : "must be valid region name";
+
+	const validateValidSeriesName: (value: any, instance: any, state: any) => string =
+	(value: any, instance: any, state: any) => !isDefined(value) || SERIES_NAME.test(value) ? null : "must be valid series name";
 
 const validateValidObjectId: (value: any, instance: any, state: any) => string =
 	(value: any, instance: any, state: any) => !isDefined(value) || OBJECT_ID.test(value) ? null : "must be valid object id";
@@ -60,6 +63,7 @@ function validateNotDefinedIf(predicate: Predicate<any>, expectation: string): (
 export {
 	validateDefined,
 	validateValidRegionName,
+	validateValidSeriesName,
 	validateValidObjectId,
 	validateValidContextName,
 	validateRequestableObjectPath,

--- a/packages/cydran/test/component/renderer/StageRendererImpl.spec.ts
+++ b/packages/cydran/test/component/renderer/StageRendererImpl.spec.ts
@@ -18,12 +18,12 @@ describe("StageRendererImpl", () => {
 	});
 
 	test("renderer is whole and ready", () => {
-		renderer = new StageRendererImpl(rootSelector, [], []);
+		renderer = new StageRendererImpl(rootSelector);
 		expect(renderer).not.toBeNull();
 	});
 
 	test("render the template", () => {
-		renderer = new StageRendererImpl(rootSelector, [], []);
+		renderer = new StageRendererImpl(rootSelector);
 		const result: HTMLElement = renderer.render();
 		expect(result instanceof HTMLElement).toBe(true);
 		const expected: string = '<body><c-series name="top"></c-series><c-region name="body"></c-region><c-series name="bottom"></c-series></body>';
@@ -32,7 +32,7 @@ describe("StageRendererImpl", () => {
 
 	test("render the template: throw SelectorError", () => {
 		const divTag: HTMLDivElement = DomUtils.getDocument().createElement("div");
-		renderer = new StageRendererImpl("#xyz", [], []);
+		renderer = new StageRendererImpl("#xyz");
 		expect(() => { renderer.render(); }).toThrowError(SelectorError);
 	});
 
@@ -54,7 +54,7 @@ describe("StageRendererImpl", () => {
 		}
 		console.log(`bodyTag: ${DomUtils.getDocument().querySelector("body").outerHTML}`);
 
-		renderer = new StageRendererImpl(`#${idVal}2`, [], []);
+		renderer = new StageRendererImpl(`#${idVal}2`);
 		expect(() => { renderer.render(); }).not.toThrowError(SelectorError);
 	});
 

--- a/packages/cydran/test/component/renderer/StageRendererImpl.spec.ts
+++ b/packages/cydran/test/component/renderer/StageRendererImpl.spec.ts
@@ -26,7 +26,7 @@ describe("StageRendererImpl", () => {
 		renderer = new StageRendererImpl(rootSelector, [], []);
 		const result: HTMLElement = renderer.render();
 		expect(result instanceof HTMLElement).toBe(true);
-		const expected: string = '<body><c-region name="body"></c-region></body>';
+		const expected: string = '<body><c-series name="top"></c-series><c-region name="body"></c-region><c-series name="bottom"></c-series></body>';
 		expect(result.outerHTML).toEqual(expected);
 	});
 

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -32,11 +32,13 @@ describe("Series", () => {
 	});
 
 	test("insertLast - Single component", () => {
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
 		specimen.getStage().before().insertLast(new TextComponent("Foo"));
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
 	test("insertLast - Multiple components", () => {
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
 		specimen.getStage().before().insertLast(new TextComponent("Foo"));
 		specimen.getStage().before().insertLast(new TextComponent("Bar"));
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
@@ -197,13 +199,28 @@ describe("Series", () => {
 		expect(specimen.getStage().before().contains(fourth)).toEqual(true);		
 	});
 
+	test("insertFirst - Single component", () => {
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().insertFirst(new TextComponent("Foo"));
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("insertFirst - Multiple components", () => {
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().insertFirst(new TextComponent("Foo"));
+		specimen.getStage().before().insertFirst(new TextComponent("Bar"));
+		specimen.expectBody().toEqual("<!--SS--><p>Bar</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		specimen.getStage().before().insertFirst(new TextComponent("Baz"));
+		specimen.getStage().before().insertFirst(new TextComponent("Bat"));
+		specimen.expectBody().toEqual("<!--SS--><p>Bat</p><p>Baz</p><p>Bar</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
 	// TODO: 
 	// replace - Existing component, non-existing component
 	// replaceAt - Existing index, non-existing index, out of range index before, out of range index after
 	// insertBefore - Existing index, non-existing index, out of range index before, out of range index after
 	// insertAfter - Existing index, non-existing index, out of range index before, out of range index after
-	// insertFirst - Emppy series, non-empty series
-	// insertLast - Emppy series, non-empty series
 
 	// TODO - Check null guarding of all input
 

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -216,8 +216,48 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><p>Bat</p><p>Baz</p><p>Bar</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
+	test("replace - existing component", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		// Initial state
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		// Replace middle
+		specimen.getStage().before().replace(second, fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bat</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		// Replace first
+		specimen.getStage().before().replace(first, second);
+		specimen.expectBody().toEqual("<!--SS--><p>Bar</p><p>Bat</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		// Replace last
+		specimen.getStage().before().replace(third, first);
+		specimen.expectBody().toEqual("<!--SS--><p>Bar</p><p>Bat</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("replace - non-existing component", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		specimen.getStage().before().replace(second, fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+
 	// TODO: 
-	// replace - Existing component, non-existing component
+	// 
 	// replaceAt - Existing index, non-existing index, out of range index before, out of range index after
 	// insertBefore - Existing index, non-existing index, out of range index before, out of range index after
 	// insertAfter - Existing index, non-existing index, out of range index before, out of range index after

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -104,8 +104,8 @@ describe("Series", () => {
 		expect(specimen.getStage().before().getAt(3)).toStrictEqual(fourth);
 
 		// Values out of range
-		expect(specimen.getStage().before().getAt(-1)).toBeNull();
-		expect(specimen.getStage().before().getAt(31337)).toBeNull();
+		expect(() => specimen.getStage().before().getAt(-1)).toThrowError("Index -1 is out of bounds for series with length 4");
+		expect(() => specimen.getStage().before().getAt(31337)).toThrowError("Index 31337 is out of bounds for series with length 4");
 	});
 
 	test("remove - iterative removal", () => {
@@ -163,7 +163,9 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.getStage().before().insertLast(fourth);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
-		specimen.getStage().before().removeAt(-1);
+
+		expect(() => specimen.getStage().before().removeAt(-1)).toThrowError("Index -1 is out of bounds for series with length 4");
+
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
@@ -178,7 +180,7 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.getStage().before().insertLast(fourth);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
-		specimen.getStage().before().removeAt(10);
+		expect(() => specimen.getStage().before().removeAt(10)).toThrowError("Index 10 is out of bounds for series with length 4");
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
@@ -253,6 +255,21 @@ describe("Series", () => {
 
 		specimen.getStage().before().replace(second, fourth);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("replaceAt - out of range component, above", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		expect(() => specimen.getStage().before().replaceAt(-5, fourth)).toThrowError("Index -5 is out of bounds for series with length 3");
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
 

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -312,10 +312,39 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><p>Bar</p><p>Bat</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
+	test("insertBefore - out of range index before", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		// Initial state
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		expect(() => specimen.getStage().before().insertBefore(-1, fourth)).toThrowError("Index -1 is out of bounds for series with length 3");
+	});
+
+	test("insertBefore - out of range index after", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		// Initial state
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		expect(() => specimen.getStage().before().insertBefore(10, fourth)).toThrowError("Index 10 is out of bounds for series with length 3");
+	});
 
 	// TODO: 
 	// 
-	// insertBefore - Existing index, out of range index before, out of range index after
+	// insertBefore - Existing index
 	// insertAfter - Existing index, out of range index before, out of range index after
 
 	// TODO - Check null guarding of all input

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -117,11 +117,57 @@ describe("Series", () => {
 	// TODO: 
 	// replace(oldComponent: Nestable, newComponent: Nestable): void;
 	// replaceAt(index: number, component: Nestable): void;
-	// remove(component: Nestable): void;
+
+	test("remove", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.getStage().before().insertLast(fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		specimen.getStage().before().remove(second);
+
+		expect(specimen.getStage().before().contains(first)).toEqual(true);
+		expect(specimen.getStage().before().contains(second)).toEqual(false);
+		expect(specimen.getStage().before().contains(third)).toEqual(true);
+		expect(specimen.getStage().before().contains(fourth)).toEqual(true);		
+
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().remove(fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().remove(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().remove(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().remove(first);
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
 	// removeAt(index: number): void;
 	// insertBefore(index: number, component: Nestable): void;
 	// insertAfter(index: number, component: Nestable): void;
 	// insertFirst(component: Nestable): void;
-	// contains(component: Nestable): boolean;
+
+	test("contains", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		expect(specimen.getStage().before().contains(first)).toEqual(true);
+		expect(specimen.getStage().before().contains(second)).toEqual(true);
+		expect(specimen.getStage().before().contains(third)).toEqual(false);
+		expect(specimen.getStage().before().contains(fourth)).toEqual(true);		
+	});
 
 });

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -272,12 +272,51 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
+	test("replaceAt - out of range component, below", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		expect(() => specimen.getStage().before().replaceAt(10, fourth)).toThrowError("Index 10 is out of bounds for series with length 3");
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("replaceAt - existing component", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		// Initial state
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		// Replace middle
+		specimen.getStage().before().replaceAt(1, fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bat</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		// Replace first
+		specimen.getStage().before().replaceAt(0, second);
+		specimen.expectBody().toEqual("<!--SS--><p>Bar</p><p>Bat</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		// Replace last
+		specimen.getStage().before().replaceAt(2, first);
+		specimen.expectBody().toEqual("<!--SS--><p>Bar</p><p>Bat</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
 
 	// TODO: 
 	// 
-	// replaceAt - Existing index, non-existing index, out of range index before, out of range index after
-	// insertBefore - Existing index, non-existing index, out of range index before, out of range index after
-	// insertAfter - Existing index, non-existing index, out of range index before, out of range index after
+	// insertBefore - Existing index, out of range index before, out of range index after
+	// insertAfter - Existing index, out of range index before, out of range index after
 
 	// TODO - Check null guarding of all input
 

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -1,6 +1,7 @@
 import { Component, Stage, create } from "@cydran/cydran";
 import { beforeEach, describe, expect, test } from '@jest/globals';
 import { Harness } from '@cydran/testsupport';
+import { spec } from "node:test/reporters";
 
 class BodyComponent extends Component {
 
@@ -37,12 +38,12 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
-	test("insertLeft - Single component", () => {
+	test("insertLast - Single component", () => {
 		specimen.getStage().before().insertLast(new TextComponent("Foo"));
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
-	test("insertLeft - Multiple components", () => {
+	test("insertLast - Multiple components", () => {
 		specimen.getStage().before().insertLast(new TextComponent("Foo"));
 		specimen.getStage().before().insertLast(new TextComponent("Bar"));
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
@@ -89,10 +90,31 @@ describe("Series", () => {
 		expect(specimen.getStage().before().hasComponents()).toEqual(false);
 	});
 
+	test("getAt", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.getStage().before().insertLast(fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		// Expected values that should be there
+		expect(specimen.getStage().before().getAt(0)).toStrictEqual(first);
+		expect(specimen.getStage().before().getAt(1)).toStrictEqual(second);
+		expect(specimen.getStage().before().getAt(2)).toStrictEqual(third);
+		expect(specimen.getStage().before().getAt(3)).toStrictEqual(fourth);
+
+		// Values out of range
+		expect(specimen.getStage().before().getAt(-1)).toBeNull();
+		expect(specimen.getStage().before().getAt(31337)).toBeNull();
+	});
 
 
 	// TODO: 
-	// getAt<N extends Nestable>(index: number): N;
 	// replace(oldComponent: Nestable, newComponent: Nestable): void;
 	// replaceAt(index: number, component: Nestable): void;
 	// remove(component: Nestable): void;

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -45,7 +45,8 @@ describe("Series", () => {
 
 		specimen.getStage().before().insertLast(new TextComponent("Baz"));
 		specimen.getStage().before().insertLast(new TextComponent("Bat"));
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
 	test("clear - full to empty", () => {
@@ -53,7 +54,8 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(new TextComponent("Bar"));
 		specimen.getStage().before().insertLast(new TextComponent("Baz"));
 		specimen.getStage().before().insertLast(new TextComponent("Bat"));
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
 		specimen.getStage().before().clear();
 		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
@@ -64,7 +66,9 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(new TextComponent("Bar"));
 		specimen.getStage().before().insertLast(new TextComponent("Baz"));
 		specimen.getStage().before().insertLast(new TextComponent("Bat"));
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
 		expect(specimen.getStage().before().isEmpty()).toEqual(false);
 
 		specimen.getStage().before().clear();
@@ -77,7 +81,9 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(new TextComponent("Bar"));
 		specimen.getStage().before().insertLast(new TextComponent("Baz"));
 		specimen.getStage().before().insertLast(new TextComponent("Bat"));
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
 		expect(specimen.getStage().before().hasComponents()).toEqual(true);
 
 		specimen.getStage().before().clear();
@@ -95,7 +101,8 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(second);
 		specimen.getStage().before().insertLast(third);
 		specimen.getStage().before().insertLast(fourth);
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
 		// Expected values that should be there
 		expect(specimen.getStage().before().getAt(0)).toStrictEqual(first);
@@ -105,7 +112,8 @@ describe("Series", () => {
 
 		// Values out of range
 		expect(() => specimen.getStage().before().getAt(-1)).toThrowError("Index -1 is out of bounds for series with length 4");
-		expect(() => specimen.getStage().before().getAt(31337)).toThrowError("Index 31337 is out of bounds for series with length 4");
+		expect(() => specimen.getStage().before().getAt(31337))
+			.toThrowError("Index 31337 is out of bounds for series with length 4");
 	});
 
 	test("remove - iterative removal", () => {
@@ -118,7 +126,9 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(second);
 		specimen.getStage().before().insertLast(third);
 		specimen.getStage().before().insertLast(fourth);
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
 		specimen.getStage().before().remove(second);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 		specimen.getStage().before().remove(fourth);
@@ -141,7 +151,9 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(second);
 		specimen.getStage().before().insertLast(third);
 		specimen.getStage().before().insertLast(fourth);
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
 		specimen.getStage().before().removeAt(1);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 		specimen.getStage().before().removeAt(2);
@@ -162,11 +174,13 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(second);
 		specimen.getStage().before().insertLast(third);
 		specimen.getStage().before().insertLast(fourth);
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
 		expect(() => specimen.getStage().before().removeAt(-1)).toThrowError("Index -1 is out of bounds for series with length 4");
 
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
 	test("removeAt - Out of rage below", () => {
@@ -179,9 +193,12 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(second);
 		specimen.getStage().before().insertLast(third);
 		specimen.getStage().before().insertLast(fourth);
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
 		expect(() => specimen.getStage().before().removeAt(10)).toThrowError("Index 10 is out of bounds for series with length 4");
-		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
 	test("contains - present and absent cases", () => {
@@ -215,7 +232,8 @@ describe("Series", () => {
 
 		specimen.getStage().before().insertFirst(new TextComponent("Baz"));
 		specimen.getStage().before().insertFirst(new TextComponent("Bat"));
-		specimen.expectBody().toEqual("<!--SS--><p>Bat</p><p>Baz</p><p>Bar</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Bat</p><p>Baz</p><p>Bar</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
 	test("replace - existing component", () => {
@@ -268,7 +286,9 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
-		expect(() => specimen.getStage().before().replaceAt(-5, fourth)).toThrowError("Index -5 is out of bounds for series with length 3");
+		expect(() => specimen.getStage().before().replaceAt(-5, fourth))
+			.toThrowError("Index -5 is out of bounds for series with length 3");
+
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
@@ -283,7 +303,9 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
-		expect(() => specimen.getStage().before().replaceAt(10, fourth)).toThrowError("Index 10 is out of bounds for series with length 3");
+		expect(() => specimen.getStage().before().replaceAt(10, fourth))
+			.toThrowError("Index 10 is out of bounds for series with length 3");
+
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
@@ -312,6 +334,23 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><p>Bar</p><p>Bat</p><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
+	test("insertBefore - existing index", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		// Initial state
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		specimen.getStage().before().insertBefore(1, fourth);
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bat</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
 	test("insertBefore - out of range index before", () => {
 		const first: Component = new TextComponent("Foo");
 		const second: Component = new TextComponent("Bar");
@@ -324,7 +363,8 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
-		expect(() => specimen.getStage().before().insertBefore(-1, fourth)).toThrowError("Index -1 is out of bounds for series with length 3");
+		expect(() => specimen.getStage().before().insertBefore(-1, fourth))
+			.toThrowError("Index -1 is out of bounds for series with length 3");
 	});
 
 	test("insertBefore - out of range index after", () => {
@@ -339,16 +379,26 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
-		expect(() => specimen.getStage().before().insertBefore(10, fourth)).toThrowError("Index 10 is out of bounds for series with length 3");
+		expect(() => specimen.getStage().before().insertBefore(10, fourth))
+			.toThrowError("Index 10 is out of bounds for series with length 3");
 	});
 
-	// TODO: 
-	// 
-	// insertBefore - Existing index
-	// insertAfter - Existing index, out of range index before, out of range index after
+	test("insertAfter - existing index", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
 
+		// Initial state
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
-
+		specimen.getStage().before().insertAfter(1, fourth);
+		specimen.expectBody()
+			.toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Bat</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
 
 	test("insertAfter - out of range index before", () => {
 		const first: Component = new TextComponent("Foo");
@@ -362,7 +412,8 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
-		expect(() => specimen.getStage().before().insertAfter(-1, fourth)).toThrowError("Index -1 is out of bounds for series with length 3");
+		expect(() => specimen.getStage().before().insertAfter(-1, fourth))
+			.toThrowError("Index -1 is out of bounds for series with length 3");
 	});
 
 	test("insertAfter - out of range index after", () => {
@@ -377,13 +428,67 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 
-		expect(() => specimen.getStage().before().insertAfter(10, fourth)).toThrowError("Index 10 is out of bounds for series with length 3");
+		expect(() => specimen.getStage().before().insertAfter(10, fourth))
+			.toThrowError("Index 10 is out of bounds for series with length 3");
 	});
 
+	test("getAt - null index", () => {
+		expect(() => specimen.getStage().before().getAt(null as unknown as number)).toThrowError("index shall not be null");
+	});
 
+	test("replace - null checks", () => {
+		expect(() => specimen.getStage().before().replace(null as unknown as BodyComponent, new BodyComponent()))
+			.toThrowError("oldComponent shall not be null");
 
+		expect(() => specimen.getStage().before().replace(new BodyComponent(), null as unknown as BodyComponent))
+			.toThrowError("newComponent shall not be null");
+	});
 
+	test("replaceAt - null checks", () => {
+		expect(() => specimen.getStage().before().replaceAt(null as unknown as number, new BodyComponent()))
+			.toThrowError("index shall not be null");
 
-	// TODO - Check null guarding of all input
+		expect(() => specimen.getStage().before().replaceAt(0, null as unknown as BodyComponent))
+			.toThrowError("component shall not be null");
+	});
+
+	test("remove - null checks", () => {
+		expect(() => specimen.getStage().before().remove(null as unknown as BodyComponent))
+			.toThrowError("component shall not be null");
+	});
+
+	test("removeAt - null checks", () => {
+		expect(() => specimen.getStage().before().removeAt(null as unknown as number)).toThrowError("index shall not be null");
+	});
+
+	test("insertBefore - null checks", () => {
+		expect(() => specimen.getStage().before().insertBefore(null as unknown as number, new BodyComponent()))
+			.toThrowError("index shall not be null");
+
+		expect(() => specimen.getStage().before().insertBefore(0, null as unknown as BodyComponent))
+			.toThrowError("component shall not be null");
+	});
+
+	test("insertAfter - null checks", () => {
+		expect(() => specimen.getStage().before().insertAfter(null as unknown as number, new BodyComponent()))
+			.toThrowError("index shall not be null");
+
+		expect(() => specimen.getStage().before().insertAfter(0, null as unknown as BodyComponent))
+			.toThrowError("component shall not be null");
+	});
+
+	test("insertFirst - null checks", () => {
+		expect(() => specimen.getStage().before().insertFirst(null as unknown as BodyComponent))
+			.toThrowError("component shall not be null");
+	});
+
+	test("insertLast - null checks", () => {
+		expect(() => specimen.getStage().before().insertLast(null as unknown as BodyComponent))
+			.toThrowError("component shall not be null");
+	});
+
+	test("contains - null checks", () => {
+		expect(specimen.getStage().before().contains(null as unknown as BodyComponent)).toBeFalsy();
+	});
 
 });

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -1,0 +1,69 @@
+import { Component, Stage, create } from "@cydran/cydran";
+import { beforeEach, describe, expect, test } from '@jest/globals';
+import { Harness } from '@cydran/testsupport';
+
+class BodyComponent extends Component {
+
+	constructor() {
+		super("<p>The body</p>");
+	}
+
+}
+
+class TextComponent extends Component {
+
+	constructor(text: string) {
+		super("<p>" + text + "</p>");
+	}
+
+}
+
+function expectBodyToEqual(doc: Document, expected: string): void {
+	const body: string = doc.body.innerHTML;
+	expect(body).toEqual(expected);
+}
+
+
+describe("Series", () => {
+
+	let specimen: Harness<BodyComponent> = null as unknown as Harness<BodyComponent>;
+
+	beforeEach(async () => {
+		specimen = new Harness<BodyComponent>(() => new BodyComponent());
+		specimen.start();	
+	});		
+
+	test("Empty Series", () => {
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("insertLeft - Single component", () => {
+		specimen.getStage().before().insertLast(new TextComponent("Foo"));
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("insertLeft - Multiple components", () => {
+		specimen.getStage().before().insertLast(new TextComponent("Foo"));
+		specimen.getStage().before().insertLast(new TextComponent("Bar"));
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		specimen.getStage().before().insertLast(new TextComponent("Baz"));
+		specimen.getStage().before().insertLast(new TextComponent("Bat"));
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	// TODO: 
+	// getAt<N extends Nestable>(index: number): N;
+	// replace(oldComponent: Nestable, newComponent: Nestable): void;
+	// replaceAt(index: number, component: Nestable): void;
+	// remove(component: Nestable): void;
+	// removeAt(index: number): void;
+	// insertBefore(index: number, component: Nestable): void;
+	// insertAfter(index: number, component: Nestable): void;
+	// insertFirst(component: Nestable): void;
+	// hasComponents(): boolean;
+	// contains(component: Nestable): boolean;
+	// isEmpty(): boolean;
+	// clear(): void;
+
+});

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -76,6 +76,19 @@ describe("Series", () => {
 		expect(specimen.getStage().before().isEmpty()).toEqual(true);
 	});
 
+	test("hasComponents", () => {
+		specimen.getStage().before().insertLast(new TextComponent("Foo"));
+		specimen.getStage().before().insertLast(new TextComponent("Bar"));
+		specimen.getStage().before().insertLast(new TextComponent("Baz"));
+		specimen.getStage().before().insertLast(new TextComponent("Bat"));
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		expect(specimen.getStage().before().hasComponents()).toEqual(true);
+
+		specimen.getStage().before().clear();
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		expect(specimen.getStage().before().hasComponents()).toEqual(false);
+	});
+
 
 
 	// TODO: 
@@ -87,7 +100,6 @@ describe("Series", () => {
 	// insertBefore(index: number, component: Nestable): void;
 	// insertAfter(index: number, component: Nestable): void;
 	// insertFirst(component: Nestable): void;
-	// hasComponents(): boolean;
 	// contains(component: Nestable): boolean;
 
 });

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -347,6 +347,43 @@ describe("Series", () => {
 	// insertBefore - Existing index
 	// insertAfter - Existing index, out of range index before, out of range index after
 
+
+
+
+	test("insertAfter - out of range index before", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		// Initial state
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		expect(() => specimen.getStage().before().insertAfter(-1, fourth)).toThrowError("Index -1 is out of bounds for series with length 3");
+	});
+
+	test("insertAfter - out of range index after", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		// Initial state
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		expect(() => specimen.getStage().before().insertAfter(10, fourth)).toThrowError("Index 10 is out of bounds for series with length 3");
+	});
+
+
+
+
+
 	// TODO - Check null guarding of all input
 
 });

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -1,4 +1,4 @@
-import { Component, Stage, create } from "@cydran/cydran";
+import { Component } from "@cydran/cydran";
 import { beforeEach, describe, expect, test } from '@jest/globals';
 import { Harness } from '@cydran/testsupport';
 
@@ -106,11 +106,6 @@ describe("Series", () => {
 		expect(specimen.getStage().before().getAt(31337)).toBeNull();
 	});
 
-
-	// TODO: 
-	// replace(oldComponent: Nestable, newComponent: Nestable): void;
-	// replaceAt(index: number, component: Nestable): void;
-
 	test("remove - iterative removal", () => {
 		const first: Component = new TextComponent("Foo");
 		const second: Component = new TextComponent("Bar");
@@ -185,11 +180,6 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
-
-	// insertBefore(index: number, component: Nestable): void;
-	// insertAfter(index: number, component: Nestable): void;
-	// insertFirst(component: Nestable): void;
-
 	test("contains - present and absent cases", () => {
 		const first: Component = new TextComponent("Foo");
 		const second: Component = new TextComponent("Bar");
@@ -206,5 +196,15 @@ describe("Series", () => {
 		expect(specimen.getStage().before().contains(third)).toEqual(false);
 		expect(specimen.getStage().before().contains(fourth)).toEqual(true);		
 	});
+
+	// TODO: 
+	// replace - Existing component, non-existing component
+	// replaceAt - Existing index, non-existing index, out of range index before, out of range index after
+	// insertBefore - Existing index, non-existing index, out of range index before, out of range index after
+	// insertAfter - Existing index, non-existing index, out of range index before, out of range index after
+	// insertFirst - Emppy series, non-empty series
+	// insertLast - Emppy series, non-empty series
+
+	// TODO - Check null guarding of all input
 
 });

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -1,7 +1,6 @@
 import { Component, Stage, create } from "@cydran/cydran";
 import { beforeEach, describe, expect, test } from '@jest/globals';
 import { Harness } from '@cydran/testsupport';
-import { spec } from "node:test/reporters";
 
 class BodyComponent extends Component {
 
@@ -18,12 +17,6 @@ class TextComponent extends Component {
 	}
 
 }
-
-function expectBodyToEqual(doc: Document, expected: string): void {
-	const body: string = doc.body.innerHTML;
-	expect(body).toEqual(expected);
-}
-
 
 describe("Series", () => {
 
@@ -53,7 +46,7 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
-	test("clear", () => {
+	test("clear - full to empty", () => {
 		specimen.getStage().before().insertLast(new TextComponent("Foo"));
 		specimen.getStage().before().insertLast(new TextComponent("Bar"));
 		specimen.getStage().before().insertLast(new TextComponent("Baz"));
@@ -64,7 +57,7 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
-	test("isEmpty", () => {
+	test("isEmpty - present and absent cases", () => {
 		specimen.getStage().before().insertLast(new TextComponent("Foo"));
 		specimen.getStage().before().insertLast(new TextComponent("Bar"));
 		specimen.getStage().before().insertLast(new TextComponent("Baz"));
@@ -77,7 +70,7 @@ describe("Series", () => {
 		expect(specimen.getStage().before().isEmpty()).toEqual(true);
 	});
 
-	test("hasComponents", () => {
+	test("hasComponents - present and absent cases", () => {
 		specimen.getStage().before().insertLast(new TextComponent("Foo"));
 		specimen.getStage().before().insertLast(new TextComponent("Bar"));
 		specimen.getStage().before().insertLast(new TextComponent("Baz"));
@@ -90,7 +83,7 @@ describe("Series", () => {
 		expect(specimen.getStage().before().hasComponents()).toEqual(false);
 	});
 
-	test("getAt", () => {
+	test("getAt - present and absent cases", () => {
 		const first: Component = new TextComponent("Foo");
 		const second: Component = new TextComponent("Bar");
 		const third: Component = new TextComponent("Baz");
@@ -118,7 +111,7 @@ describe("Series", () => {
 	// replace(oldComponent: Nestable, newComponent: Nestable): void;
 	// replaceAt(index: number, component: Nestable): void;
 
-	test("remove", () => {
+	test("remove - iterative removal", () => {
 		const first: Component = new TextComponent("Foo");
 		const second: Component = new TextComponent("Bar");
 		const third: Component = new TextComponent("Baz");
@@ -197,7 +190,7 @@ describe("Series", () => {
 	// insertAfter(index: number, component: Nestable): void;
 	// insertFirst(component: Nestable): void;
 
-	test("contains", () => {
+	test("contains - present and absent cases", () => {
 		const first: Component = new TextComponent("Foo");
 		const second: Component = new TextComponent("Bar");
 		const third: Component = new TextComponent("Baz");

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -129,14 +129,7 @@ describe("Series", () => {
 		specimen.getStage().before().insertLast(third);
 		specimen.getStage().before().insertLast(fourth);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
-
 		specimen.getStage().before().remove(second);
-
-		expect(specimen.getStage().before().contains(first)).toEqual(true);
-		expect(specimen.getStage().before().contains(second)).toEqual(false);
-		expect(specimen.getStage().before().contains(third)).toEqual(true);
-		expect(specimen.getStage().before().contains(fourth)).toEqual(true);		
-
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 		specimen.getStage().before().remove(fourth);
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
@@ -148,7 +141,58 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
-	// removeAt(index: number): void;
+	test("removeAt - Remove existing components", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.getStage().before().insertLast(fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().removeAt(1);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().removeAt(2);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Baz</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().removeAt(1);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().removeAt(0);
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("removeAt - Out of rage above", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.getStage().before().insertLast(fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().removeAt(-1);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("removeAt - Out of rage below", () => {
+		const first: Component = new TextComponent("Foo");
+		const second: Component = new TextComponent("Bar");
+		const third: Component = new TextComponent("Baz");
+		const fourth: Component = new TextComponent("Bat");
+
+		specimen.getStage().before().insertLast(first);
+		specimen.getStage().before().insertLast(second);
+		specimen.getStage().before().insertLast(third);
+		specimen.getStage().before().insertLast(fourth);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		specimen.getStage().before().removeAt(10);
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+
 	// insertBefore(index: number, component: Nestable): void;
 	// insertAfter(index: number, component: Nestable): void;
 	// insertFirst(component: Nestable): void;

--- a/packages/integration/test/testcase/component/series.spec.ts
+++ b/packages/integration/test/testcase/component/series.spec.ts
@@ -52,6 +52,32 @@ describe("Series", () => {
 		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
 	});
 
+	test("clear", () => {
+		specimen.getStage().before().insertLast(new TextComponent("Foo"));
+		specimen.getStage().before().insertLast(new TextComponent("Bar"));
+		specimen.getStage().before().insertLast(new TextComponent("Baz"));
+		specimen.getStage().before().insertLast(new TextComponent("Bat"));
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+
+		specimen.getStage().before().clear();
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
+	});
+
+	test("isEmpty", () => {
+		specimen.getStage().before().insertLast(new TextComponent("Foo"));
+		specimen.getStage().before().insertLast(new TextComponent("Bar"));
+		specimen.getStage().before().insertLast(new TextComponent("Baz"));
+		specimen.getStage().before().insertLast(new TextComponent("Bat"));
+		specimen.expectBody().toEqual("<!--SS--><p>Foo</p><p>Bar</p><p>Baz</p><p>Bat</p><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		expect(specimen.getStage().before().isEmpty()).toEqual(false);
+
+		specimen.getStage().before().clear();
+		specimen.expectBody().toEqual("<!--SS--><!--SE--><p>The body</p><!--SS--><!--SE-->");
+		expect(specimen.getStage().before().isEmpty()).toEqual(true);
+	});
+
+
+
 	// TODO: 
 	// getAt<N extends Nestable>(index: number): N;
 	// replace(oldComponent: Nestable, newComponent: Nestable): void;
@@ -63,7 +89,5 @@ describe("Series", () => {
 	// insertFirst(component: Nestable): void;
 	// hasComponents(): boolean;
 	// contains(component: Nestable): boolean;
-	// isEmpty(): boolean;
-	// clear(): void;
 
 });

--- a/packages/sandbox/src/component/App.html
+++ b/packages/sandbox/src/component/App.html
@@ -1,5 +1,6 @@
 <div class="main-app">
 	<c-component-styles></c-component-styles>
+	<c-series name="demo"></c-series>
 	<c-region path="menu"></c-region>
 	<c-region name="body" value="m().value"></c-region>
 	<c-region path="footer"></c-region>

--- a/packages/sandbox/src/component/App.ts
+++ b/packages/sandbox/src/component/App.ts
@@ -1,5 +1,6 @@
 import { Component, Events } from "@cydran/cydran";
 import TEMPLATE from "./App.html";
+import Community from "./Community";
 
 class App extends Component {
 

--- a/packages/sandbox/src/component/index.ts
+++ b/packages/sandbox/src/component/index.ts
@@ -1,8 +1,9 @@
-import ModalContainer from './ModalContainer';
-import { Context } from "@cydran/cydran";
+import { Stage } from "@cydran/cydran";
+import ModalContainer from "./ModalContainer";
 
-function modalCapability(context: Context): void {
-//	context.getStage().addComponentAfter(new ModalContainer());
+function modalInitializer(stage: Stage): void {
+	const container: ModalContainer = new ModalContainer();
+	stage.after().insertLast(container);
 }
 
-export { modalCapability };
+export { modalInitializer };

--- a/packages/sandbox/src/index.ts
+++ b/packages/sandbox/src/index.ts
@@ -2,7 +2,7 @@ import App from "./component/App";
 import Router from "./Router";
 import { argumentsBuilder, Context, Stage, create, ElementComponent, ArgumentType } from "@cydran/cydran";
 import behaviorCapability from "./behavior";
-import { modalCapability } from "./component/";
+import { modalInitializer } from "./component/";
 import serviceCapability from "./service/";
 import "./main.scss";
 import { galleryCapability } from "./component/gallery/";
@@ -51,7 +51,7 @@ function rootCapability(context: Context) {
 	context.registerPrototype("helloWorld", HelloWorld);
 	context.registerPrototype("repeatItem", RepeatItem);
 	context.registerPrototype("repeatEmpty", Empty);
-	context.registerPrototype("wazzup", Blog, argumentsBuilder().with("blogService").withProperty("something.cool").build());
+	context.registerPrototype("wazzup", Blog, argumentsBuilder().with("blogService").withProperty("something.cool").withProvider("footer").build());
 	context.registerImplicit("footer", FOOTER_TEMPLATE);
 	context.addChild("gallery", galleryCapability);
 	context.addChild("services", serviceCapability);
@@ -70,11 +70,11 @@ customElements.define('my-component', MyComponent as CustomElementConstructor);
 const stage: Stage = create("body", PROPERTIES, rootCapability);
 stage.getContext()
 	.configure(serviceCapability)
-	//.configure(modalCapability)
 	;
 
+stage.addInitializer(null, modalInitializer);
+
 stage.addInitializer(null, (stage: Stage) => {
-	stage.getContext().addChild("cydranComponentsModal", modalCapability)
 	stage.setComponentByObjectId("app");
 	let router: Router = stage.getContext().getObject('router');
 

--- a/packages/testsupport/src/harness/Harness.ts
+++ b/packages/testsupport/src/harness/Harness.ts
@@ -197,20 +197,15 @@ class Harness<C extends Nestable> {
 
 	private rootSupplier: () => C;
 
+	private actualProperties: any;
+
 	private initialProperties: any;
 
 	private root: C;
 
 	constructor(rootSupplier: () => C = DEFAULT_COMPONENT_SUPPLIER as () => C, properties?: any) {
 		this.rootSupplier = requireNotNull(rootSupplier, "rootSupplier");
-		const actualProperties: any = isDefined(properties) ? properties : {};
-		const defaultProperties: any = {
-			[PropertyKeys.CYDRAN_STARTUP_SYNCHRONOUS]: true,
-			[PropertyKeys.CYDRAN_LOG_LEVEL]: "WARN",
-			[PropertyKeys.CYDRAN_OVERRIDE_WINDOW]: this.window
-		};
-
-		this.initialProperties = merge([defaultProperties, actualProperties]);
+		this.actualProperties = isDefined(properties) ? properties : {};
 		this.reset();
 	}
 
@@ -219,6 +214,14 @@ class Harness<C extends Nestable> {
 
 		this.window = new JSDOM(HTML).window as unknown as Window;
 		this.document = this.window.document;
+
+		const defaultProperties: any = {
+			[PropertyKeys.CYDRAN_STARTUP_SYNCHRONOUS]: true,
+			[PropertyKeys.CYDRAN_LOG_LEVEL]: "WARN",
+			[PropertyKeys.CYDRAN_OVERRIDE_WINDOW]: this.window
+		};
+
+		this.initialProperties = merge([defaultProperties, this.actualProperties]);
 
 		this.stage = create("body", this.initialProperties);
 		this.stage.addInitializer({}, (stage: Stage) => {
@@ -255,6 +258,10 @@ class Harness<C extends Nestable> {
 
 	public getContext(): Context {
 		return this.stage.getContext();
+	}
+
+	public getStage(): Stage {
+		return this.stage;
 	}
 
 	public registerConstant(id: string, instance: any): void {
@@ -299,6 +306,10 @@ class Harness<C extends Nestable> {
 
 	public forTestId(value: string): Operations {
 		return new OperationsImpl(this.document.documentElement, value, "TestId");
+	}
+
+	public expectBody(): Matchers<any> {
+		return expect(this.document.body.innerHTML);
 	}
 
 }


### PR DESCRIPTION
- Support for the c-series element - An ordered list of components that can have components added to it similarly to a region, but with multiple components
- The related API support to interact with a c-series within a component - This includes a forSeries() method on the component actions continuation in order to do operations on a named series such as add, remove, etc.
- Fixed top and bottom series on stage component - Addition of a series at the top and bottom of the stage component via the stage renderer to restore the ability of putting arbitrary components immediately above or below the body region of the stage component.
- Restoration of example modal functionality in the sandbox project.