### PR TITLE
#767 Make name attribute accessible to component

### DIFF
--- a/packages/cydran/src/component/Component.ts
+++ b/packages/cydran/src/component/Component.ts
@@ -15,9 +15,9 @@ class Component implements Nestable {
 	 * @param options - optional {@link ComponentOptions} argument
 	 */
 	constructor(template: string | HTMLElement | Renderer, options: ComponentOptions = {}) {
-		const wkOptions: ComponentOptions = { name: this.constructor.name };
+		const nameToExistOpts: ComponentOptions = { name: this.constructor.name };
 		if (!options?.name) {
-			Object.assign(options, wkOptions);
+			Object.assign(options, nameToExistOpts);
 		}
 		this.____internal$$cydran$$init____(template, options as InternalComponentOptions);
 	}

--- a/packages/cydran/src/component/Component.ts
+++ b/packages/cydran/src/component/Component.ts
@@ -14,7 +14,7 @@ class Component implements Nestable {
 	 * @param template - string value representation of a template
 	 * @param options - optional {@link ComponentOptions} argument
 	 */
-	constructor(template: string | HTMLElement | Renderer, options: ComponentOptions = {}) {
+	constructor(template: string | HTMLElement | Renderer, options?: ComponentOptions) {
 		this.____internal$$cydran$$init____(template, options as InternalComponentOptions);
 	}
 

--- a/packages/cydran/src/component/Component.ts
+++ b/packages/cydran/src/component/Component.ts
@@ -15,10 +15,6 @@ class Component implements Nestable {
 	 * @param options - optional {@link ComponentOptions} argument
 	 */
 	constructor(template: string | HTMLElement | Renderer, options: ComponentOptions = {}) {
-		const nameToExistOpts: ComponentOptions = { name: this.constructor.name };
-		if (!options?.name) {
-			Object.assign(options, nameToExistOpts);
-		}
 		this.____internal$$cydran$$init____(template, options as InternalComponentOptions);
 	}
 

--- a/packages/cydran/src/component/Component.ts
+++ b/packages/cydran/src/component/Component.ts
@@ -14,7 +14,11 @@ class Component implements Nestable {
 	 * @param template - string value representation of a template
 	 * @param options - optional {@link ComponentOptions} argument
 	 */
-	constructor(template: string | HTMLElement | Renderer, options?: ComponentOptions) {
+	constructor(template: string | HTMLElement | Renderer, options: ComponentOptions = {}) {
+		const wkOptions: ComponentOptions = { name: this.constructor.name };
+		if (!options?.name) {
+			Object.assign(options, wkOptions);
+		}
 		this.____internal$$cydran$$init____(template, options as InternalComponentOptions);
 	}
 

--- a/packages/cydran/src/component/ComponentInternalsImpl.ts
+++ b/packages/cydran/src/component/ComponentInternalsImpl.ts
@@ -158,7 +158,7 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 	}
 
 	public bootstrap(): void {
-		this.options = merge([DEFAULT_COMPONENT_OPTIONS, this.options], { metadata: (existingValue: unknown, newValue: unknown) => merge([existingValue, newValue])});
+		this.options = merge([DEFAULT_COMPONENT_OPTIONS, { name: this.component.constructor.name }, this.options], { metadata: (existingValue: unknown, newValue: unknown) => merge([existingValue, newValue])});
 		this.options.prefix = this.options.prefix.toLowerCase();
 
 		if (!VALID_PREFIX_REGEX.test(this.options.prefix)) {

--- a/packages/cydran/src/component/ComponentOptions.ts
+++ b/packages/cydran/src/component/ComponentOptions.ts
@@ -8,6 +8,8 @@ interface ComponentOptions {
 
 	styles?: string;
 
+	name?: string;
+
 }
 
 export default ComponentOptions;

--- a/packages/cydran/src/stage/StageInternalsImpl.ts
+++ b/packages/cydran/src/stage/StageInternalsImpl.ts
@@ -184,12 +184,12 @@ class StageInternalsImpl implements StageInternals {
 		let extra: string = "";
 
 		if (isStrict) {
-			extra = `${ props.getAsString(PropertyKeys.CYDRAN_STRICT_STARTPHRASE) } - ${ props.getAsString(PropertyKeys.CYDRAN_STRICT_MESSAGE) }`;
+			extra = `${ props.getAsString(PropertyKeys.CYDRAN_STRICT_STARTPHRASE) }\n\t- ${ props.getAsString(PropertyKeys.CYDRAN_STRICT_MESSAGE) }`;
 		} else {
 			extra = props.getAsString(PropertyKeys.CYDRAN_LAZY_STARTPHRASE);
 		}
 
-		this.logger.ifInfo(() => `MODE: ${ modeLabel.toUpperCase() } - ${ extra }`);
+		this.logger.ifInfo(() => `MODE: ${ modeLabel.toUpperCase() }\n\t- ${ extra }`);
 	}
 
 	private completeStartup(): void {

--- a/packages/cydran/test/component/Component.spec.ts
+++ b/packages/cydran/test/component/Component.spec.ts
@@ -116,6 +116,23 @@ describe("Component", () => {
 		expect(component.getBazCount()).toEqual(2);
 	});
 
+	test("Component - null ComponentOptions - component still knows its name", () => {
+		const specimen: Component = new SimpleComponent("<div></div>");
+		expect(specimen.$c().getName()).toEqual(SimpleComponent.name);
+	});
+
+	test("Component - with ComponentOptions - component takes name from options", () => {
+		const newOpts: ComponentOptions = { name: "WhackySacky" };
+		const specimen: Component = new SimpleComponent("<div></div>", newOpts);
+		expect(specimen.$c().getName()).toEqual(newOpts.name);
+	});
+	
+	test("Component - with ComponentOptions - component derives name without a name in options", () => {
+		const newOpts: ComponentOptions = {};
+		const specimen: Component = new SimpleComponent("<div></div>", newOpts);
+		expect(specimen.$c().getName()).toEqual(SimpleComponent.name);
+	});
+
 	test("Component - Constructor() - null template", () => {
 		assertNullGuarded("template", () => new SimpleComponent(null));
 	});


### PR DESCRIPTION
Addresses name of component not getting populated correctly during instantiation as described in #767 