### PR TITLE
776 Improved forForm error message

### DIFF
--- a/packages/cydran/src/component/ComponentInternalsImpl.ts
+++ b/packages/cydran/src/component/ComponentInternalsImpl.ts
@@ -436,7 +436,7 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 		const form: HTMLFormElement = this.getNamedForm(name);
 
 		if (!isDefined(form)) {
-			throw new UnknownElementError(`Unknown form: ${name}`);
+			throw new UnknownElementError(`Unknown form: ${name}.  The c-id atttibute may not be present on the form element.`);
 		}
 
 		return new FormOperationsImpl(form);


### PR DESCRIPTION
Improved error message when using formForm() without an id that was previously registered using the c-id attribute within the component template.