### PR TITLE
Bug 765 correct misuse of c checked in readonly html in sandbox

### DIFF
--- a/packages/sandbox/src/component/gallery/ReadOnly.html
+++ b/packages/sandbox/src/component/gallery/ReadOnly.html
@@ -71,12 +71,6 @@
 			<div class="control">
 				<button c-onclick="m().toggleLineEditable()" class="button">Editable</button>
 			</div>
-			<div class="control">
-				<label class="radio">
-					<input type="radio" c-checked="!m().lineEditable" c-onclick="m().toggleLineEditable()" />
-					Editable
-				</label>
-			</div>
 		</div>
 
 	</div>


### PR DESCRIPTION
Summary of changes:

- Removed mistakenly added code from readonly gallery example.