### PR TITLE
Added guarding of $c()

### DIFF
--- a/packages/cydran/src/component/Component.ts
+++ b/packages/cydran/src/component/Component.ts
@@ -15,6 +15,7 @@ class Component implements Nestable {
 	 * @param options - optional {@link ComponentOptions} argument
 	 */
 	constructor(template: string | HTMLElement | Renderer, options?: ComponentOptions) {
+		this.____internal$$cydran____ = null as unknown as ComponentInternals;
 		this.____internal$$cydran$$init____(template, options as InternalComponentOptions);
 	}
 

--- a/packages/cydran/src/component/ComponentInternalsImpl.ts
+++ b/packages/cydran/src/component/ComponentInternalsImpl.ts
@@ -33,7 +33,7 @@ import stateMachineBuilder from "machine/StateMachineBuilder";
 import ComponentInternals from "component/ComponentInternals";
 import { Events, TagNames, DigestionActions, JSType, INTERNAL_CHANNEL_NAME, DEFAULT_CLONE_DEPTH, DEFAULT_EQUALS_DEPTH, ANONYMOUS_REGION_PREFIX, PropertyKeys, FORM_KEY, REGION_NAME, To, SERIES_NAME } from "CydranConstants";
 import emptyObject from "function/emptyObject";
-import { UnknownRegionError, TemplateError, UnknownElementError, SetComponentError, ValidationError, ContextUnavailableError } from "error/Errors";
+import { UnknownRegionError, TemplateError, UnknownElementError, SetComponentError, ValidationError, ContextUnavailableError } from 'error/Errors';
 import { isDefined, requireNotNull, merge, equals, clone, extractClassName, defaulted, requireValid, concat, exactlyOneDefined } from 'util/Utils';
 import MediatorTransitions from "mediator/MediatorTransitions";
 import InternalBehaviorFlags from "behavior/InternalBehaviorFlags";
@@ -131,10 +131,13 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 
 	private parentContext: Context;
 
+	private ready: boolean;
+
 	constructor(component: Nestable, template: string | HTMLElement | Renderer, options: InternalComponentOptions) {
+		this.ready = false;
 		this.template = requireNotNull(template, TagNames.TEMPLATE);
 		this.component = requireNotNull(component, "component");
-		this.context = null;
+		this.context = null as unknown as Context;
 		this.options = options;
 		this.itemFn = () => this.getData();
 		this.machineState = COMPONENT_MACHINE.create(this);
@@ -253,6 +256,7 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 		this.behaviors.setContext(this.getContext());
 		this.tellBehaviors(ComponentTransitions.MOUNT);
 		this.tellMediators(MediatorTransitions.MOUNT);
+		this.ready = true;
 		this.component.onMount();
 		this.intervals.enable();
 	}
@@ -603,7 +607,7 @@ class ComponentInternalsImpl implements ComponentInternals, Tellable {
 	}
 
 	public $c(): ActionContinuation {
-		return new ActionContinuationImpl(this.component, this);
+		return new ActionContinuationImpl(this.component, this, () => this.ready);
 	}
 
 	public addInterval(callback: () => void, delay?: number): void {

--- a/packages/cydran/src/continuation/ActionContinuationImpl.ts
+++ b/packages/cydran/src/continuation/ActionContinuationImpl.ts
@@ -15,6 +15,8 @@ import SendContinuationImpl from 'continuation/SendContinuationImpl';
 import IntervalContinuationImpl from "continuation/IntervalContinuationImpl";
 import { ActionContinuation, Context, Nestable, RegionContinuation, SeriesOperations } from "context/Context";
 import { CallBackThisObject } from 'CydranTypes';
+import { Supplier } from "interface/Predicate";
+import { ComponentReadinessError } from "error/Errors";
 
 class ActionContinuationImpl implements ActionContinuation {
 
@@ -22,9 +24,12 @@ class ActionContinuationImpl implements ActionContinuation {
 
 	private internals: ComponentInternals;
 
-	constructor(component: Nestable, internals: ComponentInternals) {
+	private readySupplier: Supplier<boolean>;
+
+	constructor(component: Nestable, internals: ComponentInternals, readySupplier: Supplier<boolean>) {
 		this.component = requireNotNull(component, "component");
 		this.internals = requireNotNull(internals, "internals");
+		this.readySupplier = requireNotNull(readySupplier, "readySupplier");
 	}
 	
 	public getContext(): Context {
@@ -52,22 +57,32 @@ class ActionContinuationImpl implements ActionContinuation {
 	}
 
 	public regions(): RegionContinuation {
+		this.guardReady();
+
 		return new RegionContinuationImpl(this.internals);
 	}
 
 	public forSeries(name: string): SeriesOperations {
+		this.guardReady();
+
 		return this.internals.forSeries(name);
 	}
 
 	public forElement<E extends HTMLElement>(name: string): ElementOperations<E> {
+		this.guardReady();
+
 		return this.internals.forElement(name);
 	}
 
 	public forForm(name: string): FormOperations {
+		this.guardReady();
+
 		return this.internals.forForm(name);
 	}
 
 	public forForms(): FormOperations {
+		this.guardReady();
+
 		return this.internals.forForms();
 	}
 
@@ -124,6 +139,8 @@ class ActionContinuationImpl implements ActionContinuation {
 	}
 
 	public properties(): Properties {
+		this.guardReady();
+
 		return this.internals.getContext().getProperties();
 	}
 
@@ -147,6 +164,11 @@ class ActionContinuationImpl implements ActionContinuation {
 		return this.internals.getData() as T;
 	}
 
+	private guardReady(): void {
+		if (!this.readySupplier()) {
+			throw new ComponentReadinessError("Component is not ready for action continuations. Ensure that the component is ready before invoking actions.");
+		}
+	}
 }
 
 export default ActionContinuationImpl;

--- a/packages/cydran/src/error/Errors.ts
+++ b/packages/cydran/src/error/Errors.ts
@@ -279,11 +279,19 @@ class BoundsError extends CydranError {
 	}
 
 }
+class ComponentReadinessError extends CydranError {
+
+	constructor(msg: string) {
+		super(msg);
+	}
+
+}
 
 export {
 	BehaviorError,
 	CydranError,
 	ComponentStateError,
+	ComponentReadinessError,
 	AmbiguousMarkupError,
 	DigestLoopError,
 	InvalidTypeError,

--- a/packages/cydran/src/test/TestUtils.ts
+++ b/packages/cydran/src/test/TestUtils.ts
@@ -131,14 +131,14 @@ function assertThrown(expected: string, activity: () => void, expectedType?: str
 
 function assertNullGuarded(expected: string, activity: () => void, expectedType?: string) {
 	const actualExpectedType = (expectedType === null || expectedType === undefined) ? "NullValueError" : expectedType;
-	let thrown: Error = null;
+	let thrown: Error = null as unknown as Error;
 
 	const actualExpected: string = expected.includes(" ") ? expected : `${ expected } shall not be null`;
 
 	try {
 		activity();
 	} catch (e) {
-		thrown = e;
+		thrown = e as Error;
 	}
 
 	if (!isDefined(thrown)) {

--- a/packages/cydran/test/component/Component.spec.ts
+++ b/packages/cydran/test/component/Component.spec.ts
@@ -1,4 +1,4 @@
-import { assertNoErrorThrown, assertNullGuarded } from "test/TestUtils";
+import { assertNoErrorThrown, assertNullGuarded, assertThrown } from 'test/TestUtils';
 import { Context } from 'context/Context';
 import Component from 'component/Component';
 import ScopeImpl from 'scope/ScopeImpl';
@@ -96,7 +96,7 @@ describe("Component", () => {
 			specimen = new RegionAtRootComponent();
 			specimen.$c().tell("setParentContext", new GlobalContextImpl().createChild());
 		} catch (e) {
-			thrown = e;
+			thrown = e as Error;
 		}
 
 		expect(thrown).not.toBeNull();
@@ -142,7 +142,7 @@ describe("Component", () => {
 		try {
 			specimen = new SimpleComponent({} as string);
 		} catch (e) {
-			thrown = e;
+			thrown = e as Error;
 		}
 
 		expect(thrown).not.toBeNull();
@@ -155,15 +155,27 @@ describe("Component", () => {
 	});
 
 	test("Component - setChild() - null name", () => {
-		assertNullGuarded("name", () => new TestComponent().$c().regions().set(null, new SimpleComponent(ROOT_TEMPLATE)));
+		assertThrown(
+			"Component is not ready for action continuations. Ensure that the component is ready before invoking actions.",
+			() => new TestComponent().$c().regions().set(null, new SimpleComponent(ROOT_TEMPLATE)),
+			"ComponentReadinessError"
+		);
 	});
 
 	test("Component - setByObjectId() - null name", () => {
-		assertNullGuarded("name", () => new TestComponent().$c().regions().setByObjectId(null, "componentName"));
+		assertThrown(
+			"Component is not ready for action continuations. Ensure that the component is ready before invoking actions.",
+			() => new TestComponent().$c().regions().setByObjectId(null, "componentName"),
+			"ComponentReadinessError"
+		);
 	});
 
 	test("Component - setByObjectId() - null componentId", () => {
-		assertNullGuarded("componentId", () => new TestComponent().$c().regions().setByObjectId("name", null));
+		assertThrown(
+			"Component is not ready for action continuations. Ensure that the component is ready before invoking actions.",
+			() => new TestComponent().$c().regions().setByObjectId("name", null),
+			"ComponentReadinessError"
+		);
 	});
 
 	test("Component - metadata().get() - null name", () => {
@@ -193,7 +205,11 @@ describe("Component", () => {
 	});
 
 	test("Component - hasRegion() - null name", () => {
-		assertNullGuarded("name", () => new SimpleComponent(ROOT_TEMPLATE).$c().regions().has(null));
+		assertThrown(
+			"Component is not ready for action continuations. Ensure that the component is ready before invoking actions.",
+			() => new SimpleComponent(ROOT_TEMPLATE).$c().regions().has(null),
+			"ComponentReadinessError"
+		);
 	});
 
 	test("Component - getObject() - null id", () => {


### PR DESCRIPTION
Summary of changes:

- Added boolean field to track component readiness
- Added ComponentReadinessError
- Added guarding method to fluent actions class
- Opted in to guarding key methods that would cause errors if accessed before component readiness